### PR TITLE
Fix problem where cuda is not available on ubuntu

### DIFF
--- a/src/transcribe_anything/insanley_fast_whisper_reqs.py
+++ b/src/transcribe_anything/insanley_fast_whisper_reqs.py
@@ -184,7 +184,6 @@ def _get_reqs_generic(has_nvidia: bool) -> list[str]:
         "pyannote.audio==3.3.2",
         "openai-whisper==20240930",
         "insanely-fast-whisper==0.0.15",
-        "torchaudio==2.6.0",
         "datasets==2.17.1",
         "pytorch-lightning==2.5.0",
         "torchmetrics==1.6.1",
@@ -201,8 +200,10 @@ def _get_reqs_generic(has_nvidia: bool) -> list[str]:
         content_lines.append(dep)
     if has_nvidia:
         content_lines.append(f"torch=={TENSOR_CUDA_VERSION}")
+        content_lines.append(f"torchaudio=={TENSOR_CUDA_VERSION}")
     else:
         content_lines.append(f"torch=={TENSOR_VERSION}")
+        content_lines.append(f"torchaudio=={TENSOR_VERSION}")        
     if sys.platform != "darwin":
         # Add the windows specific dependencies.
         content_lines.append("intel-openmp==2024.0.3")
@@ -240,10 +241,13 @@ def get_environment() -> IsoEnv:
     if has_nvidia:
         content_lines.append("[tool.uv.sources]")
         content_lines.append("torch = [")
-        content_lines.append("  { index = 'pytorch-cu121' },")
+        content_lines.append("  { index = 'pytorch-cu126' },")
+        content_lines.append("]")
+        content_lines.append("torchaudio = [")
+        content_lines.append("  { index = 'pytorch-cu126' },")
         content_lines.append("]")
         content_lines.append("[[tool.uv.index]]")
-        content_lines.append('name = "pytorch-cu121"')
+        content_lines.append('name = "pytorch-cu126"')
         content_lines.append(f'url = "{EXTRA_INDEX_URL}"')
         content_lines.append("explicit = true")
 


### PR DESCRIPTION
With this fix I solved the problem I had related to #31 
The problem that is found not only on docker, but also on ubuntu on classic vm, is related to the lack of cuda packages for torchaudio, which generated this error:

`OSError: /usr/local/lib/python3.10/dist-packages/transcribe_anything/venv/insanely_fast_whisper/.venv/lib/python3.11/site-packages/torchaudio/lib/libtorchaudio.so: undefined symbol: _ZNK5torch8autograd4Node4nameEv`

I enabled cuda support, if it is available on the system, using the `has_nvidia` variable which if it is true, inserts `TENSOR_CUDA_VERSION` otherwise it uses `TENSOR_VERSION` as already done for torch.
