### PR TITLE
PR: Fix SRT file generation when using --device mps Issue

### DIFF
--- a/src/transcribe_anything/whisper_mac.py
+++ b/src/transcribe_anything/whisper_mac.py
@@ -1,19 +1,19 @@
 """
-Runs whisper api.
+Runs whisper api with Apple MPS support.
 """
 
+import json
 import subprocess
 import sys
 import time
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Dict, Any
 
+import webvtt  # type: ignore
 from iso_env import IsoEnv, IsoEnvArgs, PyProjectToml  # type: ignore
 
 HERE = Path(__file__).parent
 CUDA_AVAILABLE: Optional[bool] = None
-
-# whisper-mps --file-name tests/localfile/video.mp4
 
 
 def get_environment() -> IsoEnv:
@@ -31,6 +31,7 @@ def get_environment() -> IsoEnv:
     content_lines.append('requires-python = "==3.11.*"')
     content_lines.append("dependencies = [")
     content_lines.append('  "whisper-mps",')
+    content_lines.append('  "webvtt-py",')
     content_lines.append("]")
     content = "\n".join(content_lines)
     pyproject_toml = PyProjectToml(content)
@@ -39,27 +40,70 @@ def get_environment() -> IsoEnv:
     return env
 
 
+def _format_timestamp(seconds: float) -> str:
+    """Format seconds into SRT timestamp format."""
+    milliseconds = int(seconds * 1000)
+    hours = milliseconds // 3_600_000
+    milliseconds -= hours * 3_600_000
+    minutes = milliseconds // 60_000
+    milliseconds -= minutes * 60_000
+    seconds = milliseconds // 1_000
+    milliseconds -= seconds * 1_000
+    return f"{hours:02d}:{minutes:02d}:{seconds:02d},{milliseconds:03d}"
+
+
+def _json_to_srt(json_data: Dict[str, Any]) -> str:
+    """Convert whisper-mps JSON output to SRT format."""
+    srt_content = ""
+
+    if "segments" not in json_data:
+        # If no segments, try to create a single segment from the full text
+        if "text" in json_data:
+            srt_content = "1\n00:00:00,000 --> 00:01:00,000\n" + json_data["text"] + "\n\n"
+        return srt_content
+
+    for i, segment in enumerate(json_data["segments"], start=1):
+        start_time = segment.get("start", 0)
+        end_time = segment.get("end", start_time + 5)  # Default to 5 seconds if no end time
+        text = segment.get("text", "").strip()
+
+        if text:  # Only include non-empty segments
+            srt_content += f"{i}\n"
+            srt_content += f"{_format_timestamp(start_time)} --> {_format_timestamp(end_time)}\n"
+            srt_content += f"{text}\n\n"
+
+    return srt_content
+
+
 def run_whisper_mac_english(  # pylint: disable=too-many-arguments
     input_wav: Path,
     model: str,
     output_dir: Path,
 ) -> None:
-    """Runs whisper."""
+    """Runs whisper with Apple MPS acceleration.
+
+    This function executes the whisper-mps command to transcribe audio using Apple's
+    Metal Performance Shaders (MPS) for acceleration on Apple Silicon hardware.
+    It then processes the JSON output to generate SRT, VTT, and TXT files.
+    """
     input_wav_abs = input_wav.resolve()
     if not output_dir.exists():
         output_dir.mkdir(parents=True)
     env = get_environment()
-    cmd_list = []
-    cmd_list.append("whisper-mps")
-    cmd_list.append("--file-name")
-    cmd_list.append(input_wav.name)  # cwd is set to the same directory as the input file.
-    if model:
-        cmd_list.append("--model")
-        cmd_list.append(model)
 
-    # Remove the empty strings.
-    cmd_list = [str(x).strip() for x in cmd_list if str(x).strip()]
-    # cmd = " ".join(cmd_list)
+    # whisper-mps saves the output JSON in the same directory as the input file
+    output_json = input_wav_abs.parent / "output.json"
+
+    # Prepare command
+    cmd_list = [
+        "whisper-mps",
+        "--file-name", input_wav.name,  # cwd is set to the same directory as the input file
+    ]
+
+    if model:
+        cmd_list.extend(["--model", model])
+
+    # Execute command
     cmd = subprocess.list2cmdline(cmd_list)
     sys.stderr.write(f"Running:\n  {cmd}\n")
     proc = env.open_proc(cmd_list, shell=False, cwd=input_wav_abs.parent)
@@ -69,6 +113,40 @@ def run_whisper_mac_english(  # pylint: disable=too-many-arguments
             time.sleep(0.25)
             continue
         if rtn != 0:
-            msg = f"Failed to execute {cmd}\n "
-            raise OSError(msg)
+            raise OSError(f"Failed to execute {cmd}")
         break
+
+    # Process output files
+    if not output_json.exists():
+        raise FileNotFoundError(f"whisper-mps did not generate the expected output file: {output_json}")
+
+    # Read the JSON output
+    try:
+        with open(output_json, 'r', encoding='utf-8') as f:
+            json_data = json.load(f)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Failed to parse whisper-mps output JSON: {e}")
+
+    # Generate output files
+    # 1. SRT file
+    srt_content = _json_to_srt(json_data)
+    srt_file = output_dir / "out.srt"
+    with open(srt_file, 'w', encoding='utf-8') as f:
+        f.write(srt_content)
+
+    # 2. Text file
+    txt_file = output_dir / "out.txt"
+    with open(txt_file, 'w', encoding='utf-8') as f:
+        f.write(json_data.get("text", ""))
+
+    # 3. JSON file
+    json_out_file = output_dir / "out.json"
+    with open(json_out_file, 'w', encoding='utf-8') as f:
+        json.dump(json_data, f, ensure_ascii=False, indent=2)
+
+    # 4. VTT file
+    try:
+        vtt_file = output_dir / "out.vtt"
+        webvtt.from_srt(srt_file).save(vtt_file)
+    except Exception as e:
+        sys.stderr.write(f"Warning: Failed to convert SRT to VTT: {e}\n")


### PR DESCRIPTION
When using the --device mps option for Apple Silicon acceleration, the transcription process was failing with the error:

Error: No srt file found.
AssertionError: No srt file found.
This occurred because the whisper-mps package only generates a JSON output file, but the main transcribe function in api.py expects an SRT file to be generated.

Solution
This PR modifies the run_whisper_mac_english function in whisper_mac.py to:

Read the JSON output generated by the whisper-mps command
Convert the JSON data to SRT format
Save the SRT file in the output directory
Also generate VTT and TXT files for consistency with other transcription methods
Changes
Added JSON to SRT conversion functionality
Added helper functions for timestamp formatting
Improved code structure and documentation
Added proper error handling
Added webvtt-py as a dependency for VTT file generation
Testing
Tested on Apple Silicon Mac with sample audio files. The transcription process now completes successfully and generates all expected output files (SRT, VTT, TXT, JSON).

Benefits
Mac users with Apple Silicon processors can now use the faster MPS acceleration
Output format compatibility is maintained across all device options
Better error messages if something goes wrong
This fix enables users to take advantage of the speed improvements offered by the --device mps option without losing any functionality.