### PR TITLE
Fix cwd handling on Windows

### DIFF
--- a/src/transcribe_anything/cli_init_insane.py
+++ b/src/transcribe_anything/cli_init_insane.py
@@ -4,6 +4,7 @@ Main entry point.
 
 import logging
 import os
+import sys
 
 from transcribe_anything.insanley_fast_whisper_reqs import get_environment
 
@@ -23,7 +24,10 @@ def main() -> int:
     # locate the bundled sample.mp3
     print("Installing transcribe_anything (device insane) environment...")
     env = get_environment(has_nvidia=True)
-    env.run(["pwd"])
+    if sys.platform == "win32":
+        env.run(["python", "-c", "import os; print(os.getcwd())"])
+    else:
+        env.run([cwd])
     print("Installing static ffmpeg...")
     os.system("static_ffmpeg -version")
     return 0


### PR DESCRIPTION
```
error: Failed to spawn: `pwd`
  Caused by: program not found
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "..\Scripts\transcribe-anything-init-insane.exe\__main__.py", line 7, in <module>
  File "..\Lib\site-packages\transcribe_anything\cli_init_insane.py", line 26, in main
    env.run(["pwd"])
```