### PR TITLE
fix: setuptools>=82 build failure + whisper options caching bug

### DIFF
--- a/src/transcribe_anything/_cmd.py
+++ b/src/transcribe_anything/_cmd.py
@@ -10,6 +10,7 @@ import json
 import os
 import platform
 import sys
+import time
 import traceback
 from pathlib import Path
 
@@ -42,18 +43,17 @@ WHISPER_MODEL_OPTIONS = [
 
 
 def get_whisper_options() -> dict:
-    """Get whisper options.""" ""
-    if WHISPER_OPTIONS.exists():
+    """Get whisper options."""
+    if not WHISPER_OPTIONS.exists():
         whisper_options = parse_whisper_options()
-        string = json.dumps(whisper_options, indent=4)
-        WHISPER_OPTIONS.write_text(string)
+        WHISPER_OPTIONS.write_text(json.dumps(whisper_options, indent=4))
         return whisper_options
-    file_age = os.path.getmtime(WHISPER_OPTIONS)
+    file_age = time.time() - os.path.getmtime(WHISPER_OPTIONS)
     if file_age > 60 * 60 * 24 * 7:  # 1 week
         whisper_options = parse_whisper_options()
-        string = json.dumps(whisper_options, indent=4)
-        WHISPER_OPTIONS.write_text(string)
-    return whisper_options
+        WHISPER_OPTIONS.write_text(json.dumps(whisper_options, indent=4))
+        return whisper_options
+    return json.loads(WHISPER_OPTIONS.read_text())
 
 
 def parse_arguments() -> argparse.Namespace:

--- a/src/transcribe_anything/whisper.py
+++ b/src/transcribe_anything/whisper.py
@@ -49,8 +49,15 @@ def get_environment() -> IsoEnv:
         content_lines.append(f'  "torch=={TENSOR_VERSION}+{CUDA_VERSION}",')
     content_lines.append("]")
 
+    # Constrain setuptools < 82 for build isolation because
+    # openai-whisper imports pkg_resources which was removed in setuptools 82.
+    content_lines.append("")
+    content_lines.append("[tool.uv]")
+    content_lines.append('build-constraint-dependencies = ["setuptools<82"]')
+
     needs_extra_index = not IS_MAC and has_nvidia_smi()
     if needs_extra_index:
+        content_lines.append("")
         content_lines.append("[tool.uv.sources]")
         content_lines.append("torch = [")
         content_lines.append("  { index = 'pytorch-cu121' },")
@@ -60,12 +67,6 @@ def get_environment() -> IsoEnv:
         content_lines.append(f'url = "{EXTRA_INDEX_URL}"')
         content_lines.append("explicit = true")
 
-    # if not IS_MAC and has_nvidia_smi():
-    #     deps.append(
-    #         f"torch=={TENSOR_VERSION}+{CUDA_VERSION} --extra-index-url {EXTRA_INDEX_URL}"
-    #     )
-    # else:
-    #     deps.append(f"torch=={TENSOR_VERSION}")
     content = "\n".join(content_lines)
 
     # Debug: Log the pyproject.toml content hash to track changes


### PR DESCRIPTION
## Problem

`transcribe-anything` crashes on startup with `ModuleNotFoundError: No module named 'pkg_resources'` when using `uv >= 0.10` with `setuptools >= 82`.

Additionally, `get_whisper_options()` has inverted caching logic that always re-parses when the cache file exists and crashes with `FileNotFoundError` when it doesn't.

## Root Cause

### Bug 1: setuptools 82+ removed `pkg_resources`
`openai-whisper==20240930`'s `setup.py` does `import pkg_resources` without declaring it as a build dependency. When `uv` resolves the build environment it picks `setuptools==82.0.1` which no longer bundles `pkg_resources`.

### Bug 2: Inverted caching logic
The condition in `get_whisper_options()` is backwards — when `WHISPER_OPTIONS.json` exists, it always re-parses (calling `whisper --help` via subprocess). When it doesn't exist, it tries `os.path.getmtime()` on a missing file. Also, `file_age` compared the raw mtime (epoch seconds) instead of elapsed time since modification.

## Fix

### `whisper.py`
Added `build-constraint-dependencies = ["setuptools<82"]` to the generated whisper venv `pyproject.toml`. This tells `uv` to constrain setuptools in the build isolation environment.

### `_cmd.py`
- Flipped the condition: now creates cache when file doesn't exist, reads from cache when it does
- Fixed `file_age` to use `time.time() - os.path.getmtime()` (elapsed seconds, not epoch timestamp)
- Added missing `return` statement and `json.loads()` for reading cached data
- Added `import time`

## Testing
Verified locally: `transcribe-anything --help` works after applying both fixes.