### PR TITLE
fix(whisper_mac): drop conflicting tiktoken>=0.5.0 pin (closes #66, #67)

### DIFF
--- a/src/transcribe_anything/whisper_mac.py
+++ b/src/transcribe_anything/whisper_mac.py
@@ -26,11 +26,14 @@ def get_mlx_cache_dir() -> Path:
     return cache_dir
 
 
-def get_environment() -> IsoEnv:
-    """Returns the environment for lightning-whisper-mlx."""
-    venv_dir = HERE / "venv" / "whisper_mlx"
-    content_lines: list[str] = []
+def _make_pyproject_toml_content() -> str:
+    """Build the pyproject.toml string for the lightning-whisper-mlx venv.
 
+    Do NOT pin tiktoken here: lightning-whisper-mlx==0.0.10 hard-pins
+    tiktoken==0.3.3, so any extra tiktoken constraint makes the resolver
+    fail. See issues #66 and #67.
+    """
+    content_lines: list[str] = []
     content_lines.append("[build-system]")
     content_lines.append('requires = ["setuptools", "wheel"]')
     content_lines.append('build-backend = "setuptools.build_meta"')
@@ -41,11 +44,16 @@ def get_environment() -> IsoEnv:
     content_lines.append('requires-python = ">=3.10"')
     content_lines.append("dependencies = [")
     content_lines.append('  "lightning-whisper-mlx @ git+https://github.com/aj47/lightning-whisper-mlx.git",')
-    content_lines.append('  "tiktoken>=0.5.0",')
     content_lines.append('  "webvtt-py",')
     content_lines.append('  "numpy",')
     content_lines.append("]")
-    content = "\n".join(content_lines)
+    return "\n".join(content_lines)
+
+
+def get_environment() -> IsoEnv:
+    """Returns the environment for lightning-whisper-mlx."""
+    venv_dir = HERE / "venv" / "whisper_mlx"
+    content = _make_pyproject_toml_content()
 
     # Debug: Log the pyproject.toml content hash to track changes
     # content_hash = hashlib.md5(content.encode("utf-8")).hexdigest()[:8]

--- a/tests/test_whisper_mac_tiktoken_pin.py
+++ b/tests/test_whisper_mac_tiktoken_pin.py
@@ -1,0 +1,46 @@
+"""Regression test for issues #66 and #67.
+
+lightning-whisper-mlx==0.0.10 hard-pins tiktoken==0.3.3. If our generated
+pyproject.toml adds any conflicting tiktoken constraint (e.g. tiktoken>=0.5.0),
+uv refuses to solve the dependency graph and the MLX backend fails before it
+ever runs.
+
+This test pins down the constraint at the pyproject-string level so a future
+edit can't quietly re-introduce a conflicting tiktoken requirement.
+"""
+
+from __future__ import annotations
+
+import re
+import unittest
+
+from transcribe_anything.whisper_mac import _make_pyproject_toml_content
+
+
+# Matches any tiktoken requirement line, whether pinned, lower-bounded,
+# upper-bounded, or anything in between.
+TIKTOKEN_REQ = re.compile(r'"\s*tiktoken\s*(?P<op>[<>=!~][^"]*)?\s*"')
+
+
+class WhisperMacPyprojectTester(unittest.TestCase):
+    def test_no_conflicting_tiktoken_pin(self) -> None:
+        content = _make_pyproject_toml_content()
+        matches = TIKTOKEN_REQ.findall(content)
+        for op in matches:
+            # An empty operator string means "tiktoken" with no version
+            # constraint, which is fine — uv will resolve it via the transitive
+            # lightning-whisper-mlx pin to 0.3.3.
+            self.assertEqual(
+                op,
+                "",
+                msg=(
+                    f"whisper_mac.py pyproject pins tiktoken with '{op}', but "
+                    "lightning-whisper-mlx==0.0.10 hard-pins tiktoken==0.3.3. "
+                    "Any non-empty constraint here breaks dependency resolution "
+                    "(issues #66, #67)."
+                ),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Removes the `tiktoken>=0.5.0` dependency line that `whisper_mac.py` injected into its constructed venv `pyproject.toml`.
- `lightning-whisper-mlx==0.0.10` hard-pins `tiktoken==0.3.3`, so any extra `tiktoken` constraint makes uv reject the dependency graph before anything runs.
- Extracts `_make_pyproject_toml_content()` so the constraint is testable on any platform (no Mac/MLX runtime required).
- Adds `tests/test_whisper_mac_tiktoken_pin.py` to lock the invariant in place so a future edit cannot silently reintroduce a conflicting pin.

## Root cause

The fix for #61 (commit bb5373e) added `'  "tiktoken>=0.5.0",'` to the generated `pyproject.toml`. That constraint is unsatisfiable against lightning-whisper-mlx's own pin, producing the exact error users in #66 and #67 reported:

```
× No solution found when resolving dependencies:
╰─▶ Because only lightning-whisper-mlx==0.0.10 is available and
    lightning-whisper-mlx==0.0.10 depends on tiktoken==0.3.3, we can
    conclude that all versions of lightning-whisper-mlx depend on
    tiktoken==0.3.3. And because your project depends on
    lightning-whisper-mlx and tiktoken>=0.5.0, we can conclude that
    your project's requirements are unsatisfiable.
```

Removing the line lets uv resolve `tiktoken==0.3.3` transitively through lightning-whisper-mlx, which is what the upstream package expects.

## TDD red → green

1. **Red:** added `test_no_conflicting_tiktoken_pin` — fails on the pre-fix `_make_pyproject_toml_content()` with `'>=0.5.0' != ''`.
2. **Green:** dropped the line — test passes.

## Test plan

- [x] `pytest tests/test_whisper_mac_tiktoken_pin.py` passes (green after fix; verified red before).
- [x] Existing pure-unit tests still pass (24 passed, 2 mac-only skipped).
- [ ] Manual verification on macOS / Apple Silicon by issue reporters that `transcribe-anything ... --device mlx` no longer raises the unsatisfiable-deps error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)