### PR TITLE
fix(insane): bundle nvidia-cusparselt-cu12 on Linux so torch can import (closes #35)

### DIFF
--- a/src/transcribe_anything/insanley_fast_whisper_reqs.py
+++ b/src/transcribe_anything/insanley_fast_whisper_reqs.py
@@ -47,6 +47,12 @@ def _get_reqs_generic(has_nvidia: bool) -> list[str]:
     if has_nvidia:
         content_lines.append(f"torch=={TENSOR_CUDA_VERSION}")
         content_lines.append(f"torchaudio=={TENSOR_CUDA_VERSION}")
+        # torch 2.7.0+cu128 dlopens libcusparseLt.so.0 at import on Linux; the
+        # lib is NOT bundled with the torch wheel. nvidia-cusparselt-cu12 ships
+        # it. Without this dep, `import torch` raises ImportError and the
+        # insane backend silently falls back to CPU (see issue #35).
+        if sys.platform.startswith("linux"):
+            content_lines.append("nvidia-cusparselt-cu12")
     else:
         content_lines.append(f"torch=={TENSOR_VERSION}")
         content_lines.append(f"torchaudio=={TENSOR_VERSION}")

--- a/tests/test_insanely_fast_whisper_cusparselt.py
+++ b/tests/test_insanely_fast_whisper_cusparselt.py
@@ -1,0 +1,63 @@
+"""Regression test for issue #35.
+
+PyTorch 2.7.0+cu128 dlopens libcusparseLt.so.0 at import time on Linux. That
+library is NOT bundled with the torch wheel; it ships in the
+nvidia-cusparselt-cu12 pip package. Without that dependency, the
+insanely_fast_whisper venv imports torch, fails with::
+
+    ImportError: libcusparseLt.so.0: cannot open shared object file
+
+and silently disables CUDA — which is exactly what the user in #35 hit even
+though their `cuda_available` probe reported True.
+
+This test pins the dep at requirements-generation time so it can't be removed
+without a deliberate edit.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from unittest import mock
+
+from transcribe_anything.insanley_fast_whisper_reqs import _get_reqs_generic
+
+
+def _has_cusparselt(deps: list[str]) -> bool:
+    return any(d.startswith("nvidia-cusparselt-cu12") for d in deps)
+
+
+class CusparseltDepTester(unittest.TestCase):
+    def test_linux_with_nvidia_includes_cusparselt(self) -> None:
+        with mock.patch.object(sys, "platform", "linux"):
+            deps = _get_reqs_generic(has_nvidia=True)
+        self.assertTrue(
+            _has_cusparselt(deps),
+            msg=(
+                "On Linux + nvidia, the insanely_fast_whisper venv must include "
+                "nvidia-cusparselt-cu12 so torch 2.7.0+cu128 can find "
+                "libcusparseLt.so.0 at import time (issue #35). Current deps: "
+                f"{deps}"
+            ),
+        )
+
+    def test_linux_without_nvidia_omits_cusparselt(self) -> None:
+        with mock.patch.object(sys, "platform", "linux"):
+            deps = _get_reqs_generic(has_nvidia=False)
+        self.assertFalse(
+            _has_cusparselt(deps),
+            msg="No NVIDIA → no need for the CUDA-only cusparselt wheel.",
+        )
+
+    def test_darwin_with_nvidia_omits_cusparselt(self) -> None:
+        # has_nvidia=True is degenerate on darwin but exercise the platform gate.
+        with mock.patch.object(sys, "platform", "darwin"):
+            deps = _get_reqs_generic(has_nvidia=True)
+        self.assertFalse(
+            _has_cusparselt(deps),
+            msg="cusparselt is Linux-specific; macOS must not pull it in.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds `nvidia-cusparselt-cu12` to the `insanely_fast_whisper` venv when running on Linux with NVIDIA available.
- Fixes the silent CPU fallback in `--device insane` reported in #35 (`libcusparseLt.so.0: cannot open shared object file`).
- Adds platform-independent regression test (`tests/test_insanely_fast_whisper_cusparselt.py`) that mocks `sys.platform` so it runs on Windows, Linux, and macOS hosts.

## Root cause

`d7e0a65` (fix for #62) bumped torch to `2.7.0+cu128`. Starting with cuSPARSELt-enabled wheels (torch 2.5+), `import torch` dlopens `libcusparseLt.so.0` on Linux. That .so is **not** shipped inside the torch wheel — it lives in the separate `nvidia-cusparselt-cu12` PyPI package. With the dep missing, the import fails:

```
ImportError: libcusparseLt.so.0: cannot open shared object file: No such file or directory
…disabling cuda
Error: CUDA is not available.
```

The user in #35 had a working NVIDIA driver / `nvidia-smi` (our cuda-available probe even returned True), but `--device insane` still fell back to CPU because the torch import inside the venv crashed.

## Platform gating

| Platform        | Why                                                                 | Action |
|-----------------|---------------------------------------------------------------------|--------|
| Linux + NVIDIA  | torch wheel dlopens libcusparseLt.so.0; not bundled                  | add    |
| Linux + no GPU  | CPU-only torch doesn't need cuSPARSELt                              | skip   |
| Windows         | torch's win wheel bundles the equivalent DLL                        | skip   |
| macOS           | no NVIDIA path                                                       | skip   |

## TDD red → green

1. **Red**: `test_linux_with_nvidia_includes_cusparselt` fails — list lacks the dep.
2. **Green**: append `nvidia-cusparselt-cu12` under `if has_nvidia: ... if sys.platform.startswith('linux'):`. All three platform/GPU permutations pass.

## Test plan

- [x] New test passes (green); confirmed red before fix.
- [x] Existing `test_cuda_version_upgrade.py` (which exercises `_get_reqs_generic`) still passes — no regression.
- [x] 67 pure-unit tests pass.
- [ ] Manual verification by issue reporter on Linux that `--device insane` no longer logs `ImportError: libcusparseLt.so.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)