### PR TITLE
fix(insane): ship empty k2 stub on PYTHONPATH so speechbrain.k2_fsa loads (closes #69)

### DIFF
--- a/src/transcribe_anything/_k2_stub/__init__.py
+++ b/src/transcribe_anything/_k2_stub/__init__.py
@@ -1,0 +1,11 @@
+"""Container for the ``k2`` stub package.
+
+This directory exists only so that ``_k2_stub`` gets picked up as a
+``transcribe_anything`` sub-package by ``setuptools.packages.find`` and
+the ``k2/`` stub it contains is included in built wheels.
+
+At runtime we put the *parent* of ``k2/`` (i.e. this directory's path)
+on ``PYTHONPATH`` so the venv's Python finds ``k2`` as a top-level
+package. See ``_k2_stub_root`` and ``_prepare_subprocess_env`` in
+``transcribe_anything.insanely_fast_whisper`` and issue #69.
+"""

--- a/src/transcribe_anything/_k2_stub/k2/__init__.py
+++ b/src/transcribe_anything/_k2_stub/k2/__init__.py
@@ -1,0 +1,30 @@
+"""Stub `k2` package shipped with transcribe-anything.
+
+Why this exists
+---------------
+``speechbrain>=1.0`` ships an integration sub-package at
+``speechbrain.integrations.k2_fsa``. Its ``__init__.py`` eagerly does::
+
+    import k2  # noqa
+    ...
+    lazy_export_all(__file__, __name__, export_subpackages=True)
+
+If the real ``k2`` (https://github.com/k2-fsa/k2) is not installed, that
+import raises ``ImportError`` and the speechbrain lazy-loader propagates
+it — which crashes pyannote diarization in the insane backend on any
+platform where ``k2`` has no installable wheel (notably Windows, where
+``k2`` has no Windows wheels at all). See issue #69.
+
+What it does
+------------
+Provides an empty ``k2`` package that satisfies the ``import k2`` line.
+``lazy_export_all`` in speechbrain's k2_fsa init only registers
+sub-modules for *lazy* loading; nothing in the integration is actually
+exercised at import time, so an empty stub is sufficient to keep the
+loader from crashing.
+
+When the *real* ``k2`` is installed in the venv (e.g. Linux + CUDA
+configurations where k2 wheels are available), Python's normal import
+resolution finds the real package first — this stub does not shadow it
+unless the stub directory is explicitly the first entry on the path.
+"""

--- a/src/transcribe_anything/insanely_fast_whisper.py
+++ b/src/transcribe_anything/insanely_fast_whisper.py
@@ -29,6 +29,35 @@ HERE = Path(__file__).parent
 CUDA_INFO: Optional[CudaInfo] = None
 
 
+def _k2_stub_root() -> Path:
+    """Directory containing the ``k2`` stub package shipped with this project.
+
+    Adding this directory to ``PYTHONPATH`` lets the venv's Python satisfy
+    ``import k2`` (needed by ``speechbrain.integrations.k2_fsa`` on
+    speechbrain>=1.0) on platforms where the real ``k2`` is not installable
+    — notably Windows, where the upstream package ships no wheels. See
+    issue #69.
+    """
+    return HERE / "_k2_stub"
+
+
+def _prepare_subprocess_env(base_env: dict[str, str]) -> dict[str, str]:
+    """Return a copy of ``base_env`` augmented for the insane backend.
+
+    Adds the k2 stub directory to ``PYTHONPATH`` at the END so a real
+    ``k2`` installed in the venv (e.g. on Linux + CUDA where wheels
+    exist) still wins normal import resolution.
+    """
+    env = dict(base_env)
+    stub = str(_k2_stub_root())
+    existing = env.get("PYTHONPATH", "")
+    parts = [p for p in existing.split(os.pathsep) if p]
+    if stub not in parts:
+        parts.append(stub)
+    env["PYTHONPATH"] = os.pathsep.join(parts)
+    return env
+
+
 def get_cuda_info() -> CudaInfo:
     """Get the computing device."""
     global CUDA_INFO  # pylint: disable=global-statement
@@ -203,7 +232,7 @@ def run_insanely_fast_whisper(
     # ffmpeg paths have to be installed or else the backend tool will fail.
     static_ffmpeg.add_paths()
     iso_env = get_environment()
-    env = dict(os.environ.copy())
+    env = _prepare_subprocess_env(dict(os.environ))
     if sys.platform == "darwin":
         # Attempts fixed recommended for the mps machines. This seems
         # to be necessary since a recent update.

--- a/tests/test_k2_stub.py
+++ b/tests/test_k2_stub.py
@@ -1,0 +1,77 @@
+"""Regression tests for issue #69 (speechbrain k2_fsa ImportError).
+
+speechbrain>=1.0's ``integrations/k2_fsa/__init__.py`` does ``import k2`` at
+module load. The real ``k2`` package has no installable wheels on Windows
+(and is hard to build), so on Windows + diarization the import raises and
+crashes the entire insane backend even though pyannote doesn't actually
+need k2 features.
+
+This module locks two contracts:
+
+1. transcribe-anything ships an empty ``k2`` stub package under
+   ``transcribe_anything._k2_stub/k2/`` whose import succeeds with no
+   side effects.
+2. ``run_insanely_fast_whisper`` prepends the stub root to ``PYTHONPATH``
+   in the subprocess env so the venv's Python finds it on
+   ``import k2`` — without shadowing a real ``k2`` already on
+   ``sys.path`` (which is why we put the stub at the END, not the front).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import unittest
+
+from transcribe_anything.insanely_fast_whisper import (
+    _k2_stub_root,
+    _prepare_subprocess_env,
+)
+
+
+class K2StubExistsTester(unittest.TestCase):
+    def test_stub_root_is_real_directory_with_k2_package(self) -> None:
+        root = _k2_stub_root()
+        self.assertTrue(root.is_dir(), msg=f"{root} should be a directory")
+        self.assertTrue(
+            (root / "k2" / "__init__.py").is_file(),
+            msg=f"Expected k2/__init__.py under {root}",
+        )
+
+    def test_stub_k2_module_loads_without_side_effects(self) -> None:
+        # Loading the stub directly from its file confirms `import k2` would
+        # succeed in any subprocess that has the stub root on its sys.path.
+        init_path = _k2_stub_root() / "k2" / "__init__.py"
+        spec = importlib.util.spec_from_file_location("transcribe_anything_k2_stub", init_path)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        # Empty docstring-only module: no surprise attributes.
+        public = [a for a in dir(module) if not a.startswith("_")]
+        self.assertEqual(public, [], msg=f"Stub should be empty; found {public}")
+
+
+class PrepareSubprocessEnvTester(unittest.TestCase):
+    def test_pythonpath_includes_stub_root_when_unset(self) -> None:
+        env = _prepare_subprocess_env({})
+        stub = str(_k2_stub_root())
+        self.assertIn("PYTHONPATH", env)
+        self.assertIn(stub, env["PYTHONPATH"].split(os.pathsep))
+
+    def test_pythonpath_preserves_existing_entries_first(self) -> None:
+        existing = os.path.join("some", "existing", "path")
+        env = _prepare_subprocess_env({"PYTHONPATH": existing})
+        parts = env["PYTHONPATH"].split(os.pathsep)
+        stub = str(_k2_stub_root())
+        # Existing path stays first so a real k2 installed there wins.
+        self.assertEqual(parts[0], existing)
+        self.assertIn(stub, parts)
+
+    def test_does_not_overwrite_unrelated_env_vars(self) -> None:
+        env = _prepare_subprocess_env({"FOO": "bar", "PATH": "/usr/bin"})
+        self.assertEqual(env["FOO"], "bar")
+        self.assertEqual(env["PATH"], "/usr/bin")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Ships a tiny empty `k2` stub package and adds its parent directory to the insane backend's subprocess `PYTHONPATH`. This unblocks pyannote diarization on platforms where the real [`k2-fsa`](https://github.com/k2-fsa/k2) package can't be installed (notably Windows, which has no `k2` wheels at all).

## Root cause

`speechbrain>=1.0` ships `speechbrain/integrations/k2_fsa/__init__.py`, whose entire useful body is:

```python
try:
    import k2  # noqa
except ImportError as e:
    raise ImportError("Please install k2 to use k2\n...") from e

from speechbrain.utils.importutils import lazy_export_all
lazy_export_all(__file__, __name__, export_subpackages=True)
```

`pyannote.audio`'s speechbrain-backed speaker-embedding loader pulls in `speechbrain.integrations.k2_fsa` via the lazy-module mechanism, which makes the `import k2` line run. With no `k2` installed, that `ImportError` propagates and the insane backend crashes the moment `--hf_token` is passed (reporter in #69 confirmed: without `--hf_token`, transcription works fine).

`lazy_export_all` only **registers** sub-modules for later lazy loading; nothing inside the integration is exercised at import time. So an empty `k2` package satisfies the eager import and changes no behavior anywhere downstream.

## Why a PYTHONPATH stub rather than a real dep

- `k2-fsa` ships no Windows wheels and source-build requires a custom CUDA+C++ toolchain — not a realistic dep.
- Even on Linux, `k2` wheels exist only for narrow torch/CUDA combos. Pinning a runtime k2 would break venv resolution on hosts that don't match.
- The stub is **last** on PYTHONPATH, so a real k2 — when present — still wins normal import resolution (test_pythonpath_preserves_existing_entries_first locks this in).

## TDD red → green

1. Initial import-time RED: test module couldn't even import `_k2_stub_root` / `_prepare_subprocess_env` because they didn't exist.
2. After adding helpers + stub: 5 of 5 tests green.

Cases covered:
- Stub root is a real directory with `k2/__init__.py`.
- Loading the stub has no public side effects (no surprise attributes).
- PYTHONPATH includes stub root when env is empty.
- Existing PYTHONPATH entries stay first (regression guard for real k2).
- Unrelated env vars are preserved.

## Test plan

- [x] `pytest tests/test_k2_stub.py` (5 passed; verified red before).
- [x] 75 pure-unit tests pass; no regressions.
- [x] `find_packages` discovers `transcribe_anything._k2_stub` and `transcribe_anything._k2_stub.k2`, so the stub will ship in built wheels.
- [ ] Manual verification by issue reporter on Windows that `transcribe-anything ... --device insane --hf_token ...` no longer raises `ImportError: Please install k2 to use k2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)