### PR TITLE
fix(macos): detect x86_64 Python at startup and explain (closes #52)

### DIFF
--- a/src/transcribe_anything/_cmd.py
+++ b/src/transcribe_anything/_cmd.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from appdirs import user_cache_dir  # type: ignore
 
 from transcribe_anything.parse_whisper_options import parse_whisper_options
+from transcribe_anything.util import detect_macos_x86_unsupported
 from transcribe_anything.whisper import get_computing_device
 
 HERE = Path(os.path.abspath(os.path.dirname(__file__)))
@@ -176,6 +177,10 @@ def parse_arguments() -> argparse.Namespace:
 
 def main() -> int:
     """Main entry point for the command line tool."""
+    unsupported_msg = detect_macos_x86_unsupported()
+    if unsupported_msg is not None:
+        print(unsupported_msg, file=sys.stderr)
+        return 1
     args = parse_arguments()
     unknown = args.unknown
 

--- a/src/transcribe_anything/util.py
+++ b/src/transcribe_anything/util.py
@@ -12,7 +12,7 @@ import sys
 from dataclasses import dataclass
 from html import unescape
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Optional
 from urllib.parse import unquote
 
 PROCESS_TIMEOUT = 4 * 60 * 60
@@ -38,6 +38,83 @@ def is_mac_arm() -> bool:
 def is_mac() -> bool:
     """Returns True if the OS is macOS."""
     return platform.system() == "Darwin"
+
+
+def _check_rosetta_translated() -> Optional[int]:
+    """Probe ``sysctl.proc_translated`` to detect Rosetta on Apple Silicon.
+
+    Returns 1 if the current process is running under Rosetta, 0 if native,
+    or ``None`` if the answer can't be determined (sysctl missing / errored /
+    output unparseable / not on macOS).
+    """
+    try:
+        result = subprocess.run(
+            ["sysctl", "-n", "sysctl.proc_translated"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    try:
+        return int(result.stdout.strip())
+    except ValueError:
+        return None
+
+
+def detect_macos_x86_unsupported(
+    sys_platform: Optional[str] = None,
+    machine: Optional[str] = None,
+    rosetta_check: Optional[Callable[[], Optional[int]]] = None,
+) -> Optional[str]:
+    """Detect whether we're running an x86_64 Python on macOS.
+
+    PyTorch dropped macOS x86_64 wheels in 2.3+, so transcribe-anything's
+    whisper backend cannot install on this platform. Two failure modes hit
+    the same trap (issue #52):
+
+    * **Intel Mac** running modern macOS — fundamentally unsupported now;
+      no wheel will ever be available again upstream.
+    * **Apple Silicon Mac** with an x86_64 Python under Rosetta translation
+      (common when the user has Intel Homebrew at ``/usr/local`` instead
+      of, or in addition to, arm64 Homebrew at ``/opt/homebrew``). The fix
+      is to install an arm64-native Python.
+
+    Returns a user-facing error message if the host is in either trap, else
+    ``None``. All inputs are injectable so this can be unit-tested on
+    non-macOS hosts.
+    """
+    if sys_platform is None:
+        sys_platform = sys.platform
+    if machine is None:
+        machine = platform.machine()
+    if rosetta_check is None:
+        rosetta_check = _check_rosetta_translated
+
+    if sys_platform != "darwin":
+        return None
+    if machine != "x86_64":
+        return None
+
+    if rosetta_check() == 1:
+        return (
+            "Detected x86_64 Python running under Rosetta on Apple Silicon.\n"
+            "PyTorch no longer ships macOS x86_64 wheels, so the whisper "
+            "backend cannot install.\n"
+            "Reinstall using arm64-native Python (e.g. arm64 Homebrew at "
+            "/opt/homebrew/bin) and try again.\n"
+            "See https://github.com/zackees/transcribe-anything/issues/52"
+        )
+    return (
+        "Detected macOS on x86_64 hardware (Intel Mac).\n"
+        "PyTorch dropped macOS x86_64 wheels in 2.3+, so the whisper "
+        "backend cannot install on this platform.\n"
+        "Intel Macs are no longer supported.\n"
+        "See https://github.com/zackees/transcribe-anything/issues/52"
+    )
 
 
 def sanitize_filename(string: str) -> str:

--- a/tests/test_macos_x86_unsupported.py
+++ b/tests/test_macos_x86_unsupported.py
@@ -1,0 +1,141 @@
+"""Regression tests for issue #52.
+
+PyTorch dropped macOS x86_64 wheels in 2.3+, so transcribe-anything's
+whisper backend cannot install on x86_64 Macs — either real Intel Macs or
+Apple Silicon hosts where Python is running under Rosetta translation
+(common when the user has Intel Homebrew at /usr/local in addition to or
+instead of arm64 Homebrew at /opt/homebrew).
+
+Without an early check the failure surfaces deep inside uv as a torch
+resolution error that's hard to interpret. The helper under test detects
+both cases and returns an actionable message.
+
+All inputs to ``detect_macos_x86_unsupported`` are injectable so this test
+file runs on any host (Windows in CI here).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import unittest
+from unittest import mock
+
+from transcribe_anything.util import (
+    _check_rosetta_translated,
+    detect_macos_x86_unsupported,
+)
+
+
+class DetectMacosX86UnsupportedTester(unittest.TestCase):
+    def test_returns_none_on_linux(self) -> None:
+        msg = detect_macos_x86_unsupported(
+            sys_platform="linux",
+            machine="x86_64",
+            rosetta_check=lambda: 1,  # would say Rosetta but we're not on Mac
+        )
+        self.assertIsNone(msg)
+
+    def test_returns_none_on_windows(self) -> None:
+        msg = detect_macos_x86_unsupported(
+            sys_platform="win32",
+            machine="AMD64",
+            rosetta_check=lambda: None,
+        )
+        self.assertIsNone(msg)
+
+    def test_returns_none_on_mac_arm64(self) -> None:
+        msg = detect_macos_x86_unsupported(
+            sys_platform="darwin",
+            machine="arm64",
+            rosetta_check=lambda: 0,
+        )
+        self.assertIsNone(msg)
+
+    def test_mac_x86_under_rosetta_returns_rosetta_specific_message(self) -> None:
+        msg = detect_macos_x86_unsupported(
+            sys_platform="darwin",
+            machine="x86_64",
+            rosetta_check=lambda: 1,
+        )
+        assert msg is not None
+        self.assertIn("Rosetta", msg)
+        self.assertIn("arm64", msg)  # the suggested fix
+        self.assertIn("52", msg)  # link to the issue for context
+
+    def test_mac_x86_native_returns_intel_message(self) -> None:
+        msg = detect_macos_x86_unsupported(
+            sys_platform="darwin",
+            machine="x86_64",
+            rosetta_check=lambda: 0,
+        )
+        assert msg is not None
+        self.assertIn("Intel", msg)
+        self.assertNotIn("Rosetta", msg)
+
+    def test_mac_x86_sysctl_unavailable_falls_back_to_intel_message(self) -> None:
+        msg = detect_macos_x86_unsupported(
+            sys_platform="darwin",
+            machine="x86_64",
+            rosetta_check=lambda: None,
+        )
+        assert msg is not None
+        self.assertIn("Intel", msg)
+
+
+class CheckRosettaTranslatedTester(unittest.TestCase):
+    """Sanity checks on the subprocess-backed Rosetta probe.
+
+    These don't actually invoke sysctl on the host — they patch subprocess.run.
+    """
+
+    def _stub_sysctl(self, returncode: int, stdout: str) -> mock.MagicMock:
+        completed = mock.MagicMock()
+        completed.returncode = returncode
+        completed.stdout = stdout
+        return completed
+
+    def test_returns_1_when_sysctl_reports_translated(self) -> None:
+        with mock.patch(
+            "transcribe_anything.util.subprocess.run",
+            return_value=self._stub_sysctl(0, "1\n"),
+        ):
+            self.assertEqual(_check_rosetta_translated(), 1)
+
+    def test_returns_0_when_sysctl_reports_native(self) -> None:
+        with mock.patch(
+            "transcribe_anything.util.subprocess.run",
+            return_value=self._stub_sysctl(0, "0\n"),
+        ):
+            self.assertEqual(_check_rosetta_translated(), 0)
+
+    def test_returns_none_when_sysctl_missing(self) -> None:
+        with mock.patch(
+            "transcribe_anything.util.subprocess.run",
+            side_effect=FileNotFoundError("sysctl: command not found"),
+        ):
+            self.assertIsNone(_check_rosetta_translated())
+
+    def test_returns_none_on_sysctl_nonzero_exit(self) -> None:
+        with mock.patch(
+            "transcribe_anything.util.subprocess.run",
+            return_value=self._stub_sysctl(1, ""),
+        ):
+            self.assertIsNone(_check_rosetta_translated())
+
+    def test_returns_none_on_unparseable_output(self) -> None:
+        with mock.patch(
+            "transcribe_anything.util.subprocess.run",
+            return_value=self._stub_sysctl(0, "garbage"),
+        ):
+            self.assertIsNone(_check_rosetta_translated())
+
+    def test_returns_none_on_timeout(self) -> None:
+        with mock.patch(
+            "transcribe_anything.util.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd=["sysctl"], timeout=2),
+        ):
+            self.assertIsNone(_check_rosetta_translated())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Detects unsupported x86_64 Python on macOS at startup and exits with a clear, actionable message instead of letting `parse_whisper_options` die deep inside uv with a hard-to-interpret torch wheel error.

Two failure modes hit the same trap:

1. **Intel Mac on modern macOS** — fundamentally unsupported now; PyTorch dropped macOS x86_64 wheels in 2.3+ and no future wheel will ship.
2. **Apple Silicon Mac with x86_64 Python under Rosetta** — common when the user has Intel Homebrew at `/usr/local`. The reporter in #52 was in this exact situation, confused because `uname` showed `arm64` but `platform.machine()` from x86 Python reported `x86_64`. Fix: install arm64-native Python.

The two cases are distinguished via `sysctl sysctl.proc_translated`; the Rosetta branch points the user at `/opt/homebrew` arm64 Python explicitly.

## Before / after

**Before** (#52 reporter's actual output, surfaced only after PR #75 stopped capturing stderr):

```
error: Distribution `torch==2.7.1 @ registry+https://pypi.org/simple` can't be installed
       because it doesn't have a source distribution or wheel for the current platform
hint:  You're on macOS (`macosx_15_0_x86_64`), but `torch` (v2.7.1) only has wheels for...
       `macosx_11_0_arm64`, `win_amd64`...
```

**After**:

```
Detected x86_64 Python running under Rosetta on Apple Silicon.
PyTorch no longer ships macOS x86_64 wheels, so the whisper backend cannot install.
Reinstall using arm64-native Python (e.g. arm64 Homebrew at /opt/homebrew/bin) and try again.
See https://github.com/zackees/transcribe-anything/issues/52
```

## TDD red → green

- **Red** at import time: `_check_rosetta_translated` and `detect_macos_x86_unsupported` didn't exist.
- **Green** after adding helpers: 12 cases pass.

Coverage:

| Case                                            | Expected                          |
|-------------------------------------------------|-----------------------------------|
| Linux                                           | `None`                            |
| Windows                                         | `None`                            |
| macOS arm64                                     | `None`                            |
| macOS x86_64 + `proc_translated=1`              | Rosetta message (mentions arm64)  |
| macOS x86_64 + `proc_translated=0`              | Intel-Mac message                 |
| macOS x86_64 + sysctl missing/timeout/garbage   | Intel-Mac message (defensive)     |

Plus 6 `_check_rosetta_translated` cases covering subprocess parsing and error paths.

All 12 run on the Windows host that produced this PR by injecting `sys_platform` / `machine` / `rosetta_check` stubs into the pure-function entry point.

## Test plan

- [x] New tests: 12 passed.
- [x] Full pure-unit suite: 87 passed, 2 mac-only skipped.
- [ ] Manual confirmation by #52 reporter that installing arm64 Python at `/opt/homebrew` then re-running transcribe-anything works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)