### PR TITLE
chore: bump uv-iso-env to >=1.0.44 (picks up uv stderr surfacing in install())

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "disklru>=1.0.7",
     "FileLock",
     "webvtt-py==0.4.6",
-    "uv-iso-env>=1.0.43",
+    "uv-iso-env>=1.0.44",
     "python-dotenv>=1.0.1",
 ]
 # VERSION


### PR DESCRIPTION
## Summary

Picks up [zackees/iso-env#2](https://github.com/zackees/iso-env/pull/2). The new `uv-iso-env==1.0.44` (just released to PyPI: https://pypi.org/project/uv-iso-env/1.0.44/) replaces the bare `CalledProcessError` re-raise in `install()` with a `RuntimeError` whose message includes uv's captured stderr.

## Why this matters here

This is the diagnostic gap behind transcribe-anything#40. The reporter's traceback was:

```
File ".../iso_env/api.py", line 60, in install
    _ = subprocess.run(...)
subprocess.CalledProcessError: Command '['/opt/conda/bin/uv', 'venv']' returned non-zero exit status 2.
```

uv had stderr to share — wrong Python version, missing toolchain, etc. — but iso_env's print went to stdout (often captured) and the propagated exception's `str(e)` dropped the stderr entirely. Even after transcribe-anything#75 stopped capturing stderr at our boundary, the actionable detail was already gone before it reached us.

With 1.0.44, the same failure becomes:

```
RuntimeError: `uv venv` failed (exit 2) in /opt/.../venv/whisper: <actual uv error>
```

## Test plan

- [x] Bumped pin only — no code change in transcribe-anything.
- [x] iso-env 1.0.44 is live on PyPI (verified via `pypi.org/pypi/uv-iso-env/json`).
- [ ] Next failure report from issue #40 reporter should carry uv's actual stderr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)