### PR TITLE
fix(parse_whisper_options): print first-run install banner (refs #40)

### DIFF
--- a/src/transcribe_anything/parse_whisper_options.py
+++ b/src/transcribe_anything/parse_whisper_options.py
@@ -4,12 +4,22 @@ Parses whisper options.
 
 import re
 import subprocess
+import sys
+from pathlib import Path
 from typing import Any
 
 from transcribe_anything import logger
+from transcribe_anything.whisper import HERE as _WHISPER_HERE
 from transcribe_anything.whisper import get_environment
 
 PATTERN = r"\s+\[--(.*?)\]"
+
+_WHISPER_VENV_DIR: Path = _WHISPER_HERE / "venv" / "whisper"
+
+
+def _whisper_venv_exists() -> bool:
+    """True if the whisper venv has already been built once."""
+    return _WHISPER_VENV_DIR.exists()
 
 
 def _parse_item(item: str) -> tuple[str, Any]:
@@ -33,7 +43,19 @@ def parse_whisper_options() -> dict:
     - On non-zero exit we raise RuntimeError with an actionable message and
       the captured stderr (when available) instead of a bare CalledProcessError
       that hides the underlying cause.
+
+    Banner: when the whisper venv hasn't been built yet, iso-env's install
+    step runs `uv venv` + `uv pip compile` with capture_output=True, which
+    can look frozen for several minutes during the first dependency download.
+    We print a brief notice to stderr first so the user knows to wait
+    instead of Ctrl+C-ing (issue #40).
     """
+    if not _whisper_venv_exists():
+        sys.stderr.write(
+            "[transcribe-anything] First-run install in progress; "
+            "downloading the whisper environment can take several minutes.\n"
+        )
+        sys.stderr.flush()
     env = get_environment()
     result = env.run(
         ["whisper", "--help"],

--- a/tests/test_parse_whisper_options_first_run_banner.py
+++ b/tests/test_parse_whisper_options_first_run_banner.py
@@ -1,0 +1,89 @@
+"""Regression test for the perceived-hang UX in issue #40.
+
+When the whisper venv hasn't been built yet, ``parse_whisper_options()`` will
+trigger an iso-env install whose subprocess `uv venv` + `uv pip compile` run
+with `capture_output=True` upstream — i.e. silent for several minutes. To
+the user this looks like a hang and they Ctrl+C, producing the symptom
+reported in #40 ("nothing shown and stuck").
+
+This test pins the contract: when the venv directory does not exist,
+``parse_whisper_options()`` writes an obvious "first-run install in
+progress" banner to stderr BEFORE calling ``env.run`` so the user knows
+to wait.
+"""
+
+from __future__ import annotations
+
+import io
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from transcribe_anything import parse_whisper_options as pwo_module
+
+
+def _fake_env_run_ok(stdout: str = "") -> mock.MagicMock:
+    env = mock.MagicMock()
+    env.run.return_value = SimpleNamespace(returncode=0, stdout=stdout, stderr="")
+    return env
+
+
+class FirstRunBannerTester(unittest.TestCase):
+    def test_banner_shown_when_venv_missing(self) -> None:
+        fake_env = _fake_env_run_ok(stdout="")
+        captured = io.StringIO()
+        with mock.patch.object(pwo_module, "get_environment", return_value=fake_env):
+            with mock.patch.object(pwo_module, "_whisper_venv_exists", return_value=False):
+                with mock.patch("sys.stderr", captured):
+                    pwo_module.parse_whisper_options()
+        msg = captured.getvalue()
+        # The exact wording can evolve; pin only the bits a confused user
+        # needs to see.
+        self.assertIn("first", msg.lower())
+        self.assertIn("install", msg.lower())
+        self.assertIn("minutes", msg.lower())
+
+    def test_banner_not_shown_when_venv_exists(self) -> None:
+        fake_env = _fake_env_run_ok(stdout="")
+        captured = io.StringIO()
+        with mock.patch.object(pwo_module, "get_environment", return_value=fake_env):
+            with mock.patch.object(pwo_module, "_whisper_venv_exists", return_value=True):
+                with mock.patch("sys.stderr", captured):
+                    pwo_module.parse_whisper_options()
+        msg = captured.getvalue()
+        self.assertNotIn("first", msg.lower())
+        self.assertNotIn("install", msg.lower())
+
+    def test_banner_emitted_before_env_run(self) -> None:
+        """Order matters: banner must precede env.run, not follow it,
+        otherwise the user sits in silence for the whole install."""
+        events: list[str] = []
+
+        captured_stderr = io.StringIO()
+        original_write = captured_stderr.write
+
+        def recording_write(s: str) -> int:
+            if "first" in s.lower():
+                events.append("banner")
+            return original_write(s)
+
+        captured_stderr.write = recording_write  # type: ignore[method-assign]
+
+        fake_env = mock.MagicMock()
+
+        def fake_run(*_args, **_kwargs):
+            events.append("env.run")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        fake_env.run.side_effect = fake_run
+
+        with mock.patch.object(pwo_module, "get_environment", return_value=fake_env):
+            with mock.patch.object(pwo_module, "_whisper_venv_exists", return_value=False):
+                with mock.patch("sys.stderr", captured_stderr):
+                    pwo_module.parse_whisper_options()
+
+        self.assertEqual(events, ["banner", "env.run"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Issue #40's reporter symptom was *"First time it shows Purging... and venv_path does not exist. Then run again it shows nothing and stuck."* That isn't a literal hang — iso-env's `install()` runs `uv venv` + `uv pip compile` with `capture_output=True` upstream, so the multi-minute first dependency download is silent. Users assume frozen → Ctrl+C → `subprocess.CalledProcessError: returned non-zero exit status 2` from the killed uv.

This PR prints a one-line banner to stderr immediately **before** `env.run` when the whisper venv hasn't been built yet, so first-time users know to wait. Suppressed on subsequent runs to avoid steady-state CLI noise.

## Defense in depth chain (all three needed)

| Layer                                           | What it does                                                                | Status               |
|-------------------------------------------------|-----------------------------------------------------------------------------|----------------------|
| transcribe-anything #75                         | Stop capturing stderr / surface uv error on non-zero exit                   | merged               |
| iso-env 1.0.44 (PRs #2 there, #78 here)         | Wrap the upstream `CalledProcessError` with `RuntimeError(uv_stderr)`        | released + pinned    |
| **this PR**                                     | Print a "wait — first-run install is happening" banner before the call       | this PR              |

After this PR a first-time user gets:

```
[transcribe-anything] First-run install in progress; downloading the
whisper environment can take several minutes.
<actual uv progress now follows on stderr>
```

…and on failure, an actionable `RuntimeError: uv venv failed (exit N) in /path: <uv stderr>` from the iso-env 1.0.44 wrapping.

## TDD red → green

`tests/test_parse_whisper_options_first_run_banner.py` — 3 cases, all red on `main`:

1. Banner shown when `_whisper_venv_exists()` returns False.
2. Banner NOT shown when it returns True (steady-state quiet).
3. Banner is emitted **before** `env.run`, not after — locked via an `events: list[str]` order recorder so the regression can't sneak back.

## Test plan

- [x] 3 new tests green; red verified by attribute-error on `_whisper_venv_exists` before adding the helper.
- [x] Full pure-unit suite still passes: 90 passed, 2 mac-only skipped.
- [ ] Manual verification by #40 reporter that the next first-run install shows the banner and proceeds (or, on failure, shows the wrapped error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)