### PR TITLE
release: 3.2.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "python-dotenv>=1.0.1",
 ]
 # VERSION
-version = "3.2.8"  # Update this manually or configure setuptools-scm for automatic versioning
+version = "3.2.9"  # Update this manually or configure setuptools-scm for automatic versioning
 maintainers = [{ name = "Zachary Vorhies", email = "dont@email.me" }]
 
 [project.urls]


### PR DESCRIPTION
## Summary

Patch release bundling this session's bug-fix triage. All shipped behind regression tests (90 pure-unit tests, all green on Windows).

## Closed issues

- **#35** — `libcusparseLt.so.0` missing on Linux + nvidia → ship `nvidia-cusparselt-cu12` so torch 2.7.0+cu128 imports cleanly (PR #74).
- **#40** — First-run install looked frozen → banner in `parse_whisper_options` + iso-env 1.0.44 wraps install errors with uv stderr (PRs #75 / #78 / #79).
- **#52** — macOS x86_64 Python (Intel or Rosetta) silently failed deep in uv → detect at startup and exit with a clear message (PR #77).
- **#66 / #67** — `tiktoken>=0.5.0` conflict with `lightning-whisper-mlx==0.0.10`'s `tiktoken==0.3.3` pin → drop the constraint (PR #73).
- **#69** — speechbrain `k2_fsa` integration crashed pyannote diarization → ship empty `k2` stub on PYTHONPATH (PR #76).

## Upstream

Filed and released zackees/iso-env#1 → zackees/iso-env#2 → uv-iso-env 1.0.44 (PyPI) to surface uv's stderr in `install()` errors.

## Test plan

- [x] All 90 pure-unit tests pass.
- [ ] Tag `v3.2.9` and publish to PyPI after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)