### PR TITLE
fix(insane): bump transformers to 4.55.4 for Whisper timestamp fixes

### DIFF
--- a/src/transcribe_anything/insanley_fast_whisper_reqs.py
+++ b/src/transcribe_anything/insanley_fast_whisper_reqs.py
@@ -26,7 +26,8 @@ def get_current_python_version() -> str:
 def _get_reqs_generic(has_nvidia: bool) -> list[str]:
     """Generate the requirements for the generic case."""
     deps = [
-        "transformers==4.46.3",  # 4.47.X has problems with mac mps driver see fix: https://github.com/huggingface/transformers/pull/35295
+        # Whisper long-form/chunk timestamp fixes need >=4.53.0 (PRs #34537, #35750)
+        "transformers==4.55.4",
         "pyannote.audio==3.3.2",
         "openai-whisper==20240930",
         "insanely-fast-whisper==0.0.15",
@@ -89,6 +90,13 @@ def get_environment(has_nvidia: bool | None = None) -> IsoEnv:
     for dep in dep_lines:
         content_lines.append(f'  "{dep}",')
     content_lines.append("]")
+
+    # Constrain setuptools < 82 for build isolation because
+    # openai-whisper==20240930 imports pkg_resources, which was removed in
+    # setuptools 82. Mirrors the same guard in whisper.py.
+    content_lines.append("")
+    content_lines.append("[tool.uv]")
+    content_lines.append('build-constraint-dependencies = ["setuptools<82"]')
 
     if has_nvidia:
         content_lines.append("[tool.uv.sources]")

--- a/tests/test_insane_vs_cuda_longform_timestamps.py
+++ b/tests/test_insane_vs_cuda_longform_timestamps.py
@@ -1,0 +1,216 @@
+"""End-to-end check: --device cuda and --device insane agree on long-form timestamps.
+
+Background
+----------
+
+The HF transformers Whisper pipeline (used by ``--device insane``) had a
+chunked-decoding timestamp-offset bug that made the last segment of any
+audio longer than 30 s under-report its end time by a multiple of 30 s
+(transformers issues #34210 / #31942 / #34472, fixed in PRs #34537 and
+#35750, landing fully in transformers v4.53.0).
+
+This test bumps the bundled 10-s ``sample.mp3`` up to ~40 s by looping
+it four times, runs both backends with ``--model tiny`` (small enough
+that the test is hermetic on first run), and asserts that the last
+segment's end timestamp from each backend agrees to within 1.0 s.
+
+Before the pin bump (``transformers==4.46.3``), the insane backend
+would report a last timestamp roughly 30 s short — well outside the
+tolerance — and the test would fail loudly. After the bump
+(``transformers==4.55.4``), both backends should land near the wav's
+true duration (~40 s).
+
+Gated on the presence of NVIDIA: the insane backend is GPU-only on
+Linux/Windows, and there is no Mac path here. Skipped on hosts without
+``nvidia-smi``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+from transcribe_anything.api import transcribe
+from transcribe_anything.util import has_nvidia_smi, is_mac
+
+HERE = Path(os.path.abspath(os.path.dirname(__file__)))
+ASSETS = HERE.parent / "src" / "transcribe_anything" / "assets"
+SAMPLE_MP3 = ASSETS / "sample.mp3"
+
+CAN_RUN_TEST = has_nvidia_smi() and not is_mac() and SAMPLE_MP3.is_file()
+
+# Number of loops of the ~10 s sample.mp3 to concatenate. Four copies
+# put us well past the 30-s chunk boundary that triggers the upstream bug.
+LOOP_COUNT = 4
+
+# Tolerance between the two backends' final-segment end timestamps.
+# The legitimate per-segment-token vs per-chunk-token granularity
+# difference is at most a few hundred ms; anything larger than 1 s
+# means we're hitting the chunked-decoding rollover bug again.
+LAST_TIMESTAMP_TOLERANCE_S = 1.0
+
+# How far below / above the true audio duration the last timestamp may
+# legitimately fall. The model can stop a beat early (no speech at the
+# very end) or overshoot trailing silence by a small amount.
+WAV_DURATION_LOWER_SLACK_S = 4.0
+WAV_DURATION_UPPER_SLACK_S = 1.0
+
+
+def _make_long_wav(workdir: Path) -> Path:
+    """Use static_ffmpeg to loop sample.mp3 and render a 16 kHz mono WAV.
+
+    Returns the path to the new wav. The wav is dropped in ``workdir``.
+    """
+    import static_ffmpeg  # type: ignore[import-untyped]
+
+    static_ffmpeg.add_paths()
+    out_wav = workdir / "long_sample.wav"
+    # -stream_loop N replays the input (N+1) total times. LOOP_COUNT-1
+    # for the desired total.
+    cmd = [
+        "ffmpeg",
+        "-y",
+        "-stream_loop",
+        str(LOOP_COUNT - 1),
+        "-i",
+        str(SAMPLE_MP3),
+        "-ac",
+        "1",
+        "-ar",
+        "16000",
+        "-acodec",
+        "pcm_s16le",
+        str(out_wav),
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    assert out_wav.is_file(), f"ffmpeg returned 0 but no output wav: {result.stderr}"
+    return out_wav
+
+
+def _wav_duration_seconds(path: Path) -> float:
+    import wave
+
+    with wave.open(str(path), "rb") as w:
+        return w.getnframes() / float(w.getframerate())
+
+
+def _last_end_timestamp_from_whisper_json(path: Path) -> float:
+    """openai-whisper writes ``out.json`` with a ``segments`` list of
+    ``{start, end, text}`` dicts."""
+    data = json.loads(path.read_text(encoding="utf-8"))
+    segments = data["segments"]
+    assert segments, f"openai-whisper out.json had no segments: {data}"
+    return float(segments[-1]["end"])
+
+
+def _last_end_timestamp_from_insane_json(path: Path) -> float:
+    """The insane backend's ``out.json`` is the HF pipeline format with a
+    ``chunks`` list of ``{text, timestamp: [start, end]}`` dicts. The last
+    chunk's end timestamp may be ``None`` if the model never emitted a
+    closing timestamp token; in that case we fall back to the previous
+    chunk's end."""
+    data = json.loads(path.read_text(encoding="utf-8"))
+    chunks = data["chunks"]
+    assert chunks, f"insane out.json had no chunks: {data}"
+    for chunk in reversed(chunks):
+        end = chunk["timestamp"][1]
+        if end is not None:
+            return float(end)
+    raise AssertionError(f"no closed-end chunk in insane out.json: {chunks}")
+
+
+@unittest.skipUnless(CAN_RUN_TEST, "Requires NVIDIA (not on Mac) and bundled sample.mp3")
+class LongformTimestampAgreementTester(unittest.TestCase):
+    """Pin down that the two backends agree on the end of long audio."""
+
+    def test_last_segment_timestamps_agree_within_tolerance(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            workdir = Path(tmp)
+            long_wav = _make_long_wav(workdir)
+            wav_duration = _wav_duration_seconds(long_wav)
+            # Sanity: ensure we actually pushed past the 30-s chunk boundary.
+            self.assertGreater(
+                wav_duration,
+                30.0,
+                msg=f"Long wav is only {wav_duration:.2f}s — does not exercise multi-chunk path",
+            )
+
+            cuda_out = workdir / "out_cuda"
+            insane_out = workdir / "out_insane"
+
+            # Clean before each backend run in case a previous attempt
+            # left stale artifacts.
+            shutil.rmtree(cuda_out, ignore_errors=True)
+            shutil.rmtree(insane_out, ignore_errors=True)
+
+            # Use the public transcribe() API rather than the low-level
+            # run_whisper / run_insanely_fast_whisper helpers, because
+            # transcribe() handles the per-backend output-file renaming
+            # (openai-whisper writes <input_stem>.json; transcribe()
+            # renames everything to out.json/out.srt/etc.).
+            transcribe(
+                url_or_file=str(long_wav),
+                output_dir=str(cuda_out),
+                model="tiny",
+                task="transcribe",
+                language="en",
+                device="cuda",
+            )
+            transcribe(
+                url_or_file=str(long_wav),
+                output_dir=str(insane_out),
+                model="tiny",
+                task="transcribe",
+                language="en",
+                device="insane",
+            )
+
+            cuda_last = _last_end_timestamp_from_whisper_json(cuda_out / "out.json")
+            insane_last = _last_end_timestamp_from_insane_json(insane_out / "out.json")
+
+            # Each backend's last timestamp should bracket the true duration.
+            self.assertGreaterEqual(
+                cuda_last,
+                wav_duration - WAV_DURATION_LOWER_SLACK_S,
+                msg=f"cuda last={cuda_last:.2f}s far below wav_duration={wav_duration:.2f}s",
+            )
+            self.assertLessEqual(
+                cuda_last,
+                wav_duration + WAV_DURATION_UPPER_SLACK_S,
+                msg=f"cuda last={cuda_last:.2f}s overshot wav_duration={wav_duration:.2f}s",
+            )
+            self.assertGreaterEqual(
+                insane_last,
+                wav_duration - WAV_DURATION_LOWER_SLACK_S,
+                msg=(
+                    f"insane last={insane_last:.2f}s far below wav_duration={wav_duration:.2f}s "
+                    "— probable upstream chunked-decoding timestamp-rollover bug "
+                    "(transformers PR #35750). Check the transformers pin."
+                ),
+            )
+            self.assertLessEqual(
+                insane_last,
+                wav_duration + WAV_DURATION_UPPER_SLACK_S,
+                msg=f"insane last={insane_last:.2f}s overshot wav_duration={wav_duration:.2f}s",
+            )
+
+            # And the two backends should agree on the end-of-audio.
+            self.assertAlmostEqual(
+                cuda_last,
+                insane_last,
+                delta=LAST_TIMESTAMP_TOLERANCE_S,
+                msg=(
+                    f"cuda last={cuda_last:.2f}s vs insane last={insane_last:.2f}s differ "
+                    f"by more than {LAST_TIMESTAMP_TOLERANCE_S}s. Indicates the chunked "
+                    "decoding offset bug is back; verify transformers>=4.53.0 is actually installed."
+                ),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_transformers_version_floor.py
+++ b/tests/test_transformers_version_floor.py
@@ -1,0 +1,78 @@
+"""Regression test: pin transformers >= 4.53.0 in the insane backend venv.
+
+Three upstream Whisper bugs that affect ``--device insane``'s timestamps
+are fixed in successive transformers releases:
+
+* WhisperTokenizer chunk-offset decode — PR #34537, first in v4.47.0
+* Mac MPS float64 regression — PR #35295, first in v4.48.0
+* Long-form sequential decoding 30-s rollover — PR #35750, first in v4.53.0
+
+Anything below 4.53.0 is missing at least one of these. This test locks
+the floor so a future contributor cannot silently regress below the
+line where the upstream fixes live.
+"""
+
+from __future__ import annotations
+
+import re
+import unittest
+
+from transcribe_anything.insanley_fast_whisper_reqs import _get_reqs_generic
+
+
+TRANSFORMERS_LINE = re.compile(r"^transformers==(?P<v>\d+\.\d+\.\d+)$")
+MIN_VERSION = (4, 53, 0)
+
+
+def _find_transformers_pin(deps: list[str]) -> tuple[int, int, int] | None:
+    for dep in deps:
+        m = TRANSFORMERS_LINE.match(dep.strip())
+        if m:
+            parts = m.group("v").split(".")
+            return (int(parts[0]), int(parts[1]), int(parts[2]))
+    return None
+
+
+class TransformersFloorTester(unittest.TestCase):
+    def test_pin_is_exact_equals_style(self) -> None:
+        """The file convention is == point pins; a future loose pin (>= / ~=)
+        would defeat the floor guarantee silently."""
+        deps = _get_reqs_generic(has_nvidia=True)
+        pinned = [d for d in deps if d.strip().startswith("transformers")]
+        self.assertEqual(
+            len(pinned),
+            1,
+            msg=f"Expected exactly one transformers pin, got: {pinned}",
+        )
+        self.assertRegex(
+            pinned[0].strip(),
+            r"^transformers==\d+\.\d+\.\d+$",
+            msg=f"Expected strict '==' pin matching file convention; got {pinned[0]!r}",
+        )
+
+    def test_pin_floor_at_least_4_53_0_with_nvidia(self) -> None:
+        deps = _get_reqs_generic(has_nvidia=True)
+        version = _find_transformers_pin(deps)
+        assert version is not None, f"No transformers pin found in deps: {deps}"
+        self.assertGreaterEqual(
+            version,
+            MIN_VERSION,
+            msg=(
+                f"transformers pin {version} is below {MIN_VERSION}, which is the "
+                "minimum that contains the Whisper long-form chunked-decoding "
+                "timestamp-offset fix (PR #35750 → v4.53.0). Anything older still "
+                "exhibits the segment-rollover-every-30s bug on --device insane."
+            ),
+        )
+
+    def test_pin_floor_at_least_4_53_0_without_nvidia(self) -> None:
+        # Same floor regardless of GPU; the bug lives in the transformers
+        # library and is platform-agnostic.
+        deps = _get_reqs_generic(has_nvidia=False)
+        version = _find_transformers_pin(deps)
+        assert version is not None, f"No transformers pin found in deps: {deps}"
+        self.assertGreaterEqual(version, MIN_VERSION)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Bumps the transformers pin in the `--device insane` venv from `4.46.3` (Oct 2024) to `4.55.4` to pick up the upstream Whisper-timestamp fixes that landed between then and now.

## Why

The HF transformers Whisper pipeline (which `--device insane` ultimately invokes via `insanely-fast-whisper`) had a chunked-decoding offset bug: `WhisperTokenizer.decode` would offset timestamps incorrectly across chunks, and long-form sequential decoding would reset every 30 s. Three upstream PRs land the fixes:

| Upstream PR | First released | What it fixes |
|---|---|---|
| [#34537](https://github.com/huggingface/transformers/pull/34537) | v4.47.0 | WhisperTokenizer chunk-offset decode |
| [#35295](https://github.com/huggingface/transformers/pull/35295) | v4.48.0 | Mac MPS float64 regression (this is why our pin was frozen at 4.46.3) |
| [#35750](https://github.com/huggingface/transformers/pull/35750) | v4.53.0 | Long-form 30-s timestamp rollover |

A single bump to `4.55.4` clears all three.

## What else this required

While the new pin invalidates the on-disk venv content hash, iso-env rebuilds — and that rebuild surfaced a latent issue: `openai-whisper==20240930` fails to build under `setuptools>=82` (which removed `pkg_resources`). `whisper.py` already had a `build-constraint-dependencies = [\"setuptools<82\"]` guard; this PR adds the matching guard to `insanley_fast_whisper_reqs.py`.

## Tests (TDD red → green)

1. **`tests/test_transformers_version_floor.py`** (pure-unit, hermetic, 3 cases):
   - Pin must use `==` style (file convention)
   - `_get_reqs_generic(has_nvidia=True)` returns transformers `>= (4, 53, 0)`
   - Same for `has_nvidia=False`
   - **Red on `main` (4.46.3 < 4.53.0), green after the bump.**

2. **`tests/test_insane_vs_cuda_longform_timestamps.py`** (NVIDIA-gated, e2e):
   - Loops bundled `sample.mp3` four times via `ffmpeg -stream_loop 3` into a ~40 s wav (so it spans the 30 s chunk boundary that triggered the upstream bug).
   - Runs both backends via the public `transcribe()` API with `--model tiny`.
   - Asserts last-segment end timestamps agree within 1 s and bracket the wav's true duration.
   - **Verified locally on RTX 3060**: cuda last and insane last both land within 1 s of `wav_duration ≈ 40 s`, with the test completing in ~30 s on warm venvs.

## Test plan

- [x] `pytest tests/test_transformers_version_floor.py` (3 pass)
- [x] `pytest tests/test_insane_vs_cuda_longform_timestamps.py` (1 pass on this NVIDIA host)
- [x] Full pure-unit suite still passes (93 passed, 2 mac-only skipped)
- [ ] **Mac MPS smoke check** (out-of-band): anyone on a Mac runs `transcribe-anything <any.wav> --device mlx` against a short clip to confirm the MPS path works under transformers 4.55.4 (PR #35295 should make this work again). Not gating merge.

## Future work tracked separately

- #81 — Migrate `--device insane` backend from HF pipeline to WhisperX
- #82 — Expose `--diarization-via-whisperx` opt-in

🤖 Generated with [Claude Code](https://claude.com/claude-code)