### PR TITLE
release: 3.2.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "python-dotenv>=1.0.1",
 ]
 # VERSION
-version = "3.2.9"  # Update this manually or configure setuptools-scm for automatic versioning
+version = "3.2.10"  # Update this manually or configure setuptools-scm for automatic versioning
 maintainers = [{ name = "Zachary Vorhies", email = "dont@email.me" }]
 
 [project.urls]


### PR DESCRIPTION
## Summary

Patch release that ships PR #83's transformers pin bump + insane-backend rebuild reliability fix.

## What changed since 3.2.9

- **#83** — bumps `transformers` pin `4.46.3` → `4.55.4` in the insane-backend venv. Picks up huggingface/transformers PRs #34537 (WhisperTokenizer chunk-offset decode), #35295 (Mac MPS float64 regression), and #35750 (long-form 30-second timestamp rollover). End result: `--device insane` no longer drifts on audio longer than 30 s.
- **#83** — adds `setuptools<82` build constraint to the insane venv so `openai-whisper==20240930` keeps building (its setup.py imports `pkg_resources`, which was removed in setuptools 82).
- **#83** — NVIDIA-gated end-to-end test verifying both `--device cuda` and `--device insane` agree on last-segment timestamps within 1 s on a 40 s clip; pure-unit floor test pinning `transformers >= 4.53.0`.

## Future work tracked

- #81 — migrate `--device insane` backend from HF pipeline to WhisperX
- #82 — expose `--diarization-via-whisperx` opt-in

## Test plan

- [x] 96 pure-unit tests pass (93 baseline + 3 new floor tests).
- [x] NVIDIA-gated integration test passes locally on RTX 3060 in ~30 s.
- [ ] Tag `v3.2.10` and publish to PyPI after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)