### PR TITLE
test: fix macos cuda pyproject expectation

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ name: Lint
 on:
     push:
         branches: [ main, master ]
-    pull_request_target:
+    pull_request:
       branches: [ main, master ]
 
 

--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -3,7 +3,7 @@ name: MacOS_Tests
 on:
     push:
         branches: [ main, master ]
-    pull_request_target:
+    pull_request:
       branches: [ main, master ]
 
 jobs:

--- a/.github/workflows/test_macos_new.yml
+++ b/.github/workflows/test_macos_new.yml
@@ -3,7 +3,7 @@ name: MacOS_Mps
 on:
     push:
         branches: [ main, master ]
-    pull_request_target:
+    pull_request:
       branches: [ main, master ]
 
 jobs:

--- a/.github/workflows/test_ubuntu.yml
+++ b/.github/workflows/test_ubuntu.yml
@@ -3,7 +3,7 @@ name: Ubuntu_Tests
 on:
     push:
         branches: [ main, master ]
-    pull_request_target:
+    pull_request:
       branches: [ main, master ]
 
 jobs:

--- a/.github/workflows/test_win.yml
+++ b/.github/workflows/test_win.yml
@@ -3,7 +3,7 @@ name: Win_Tests
 on:
     push:
         branches: [ main, master ]
-    pull_request_target:
+    pull_request:
       branches: [ main, master ]
 
 jobs:

--- a/tests/test_cuda_version_upgrade.py
+++ b/tests/test_cuda_version_upgrade.py
@@ -44,6 +44,7 @@ def _capture_whisper_pyproject(has_nvidia: bool) -> str:
         patch("transcribe_anything.whisper.IsoEnvArgs", FakeIsoEnvArgs),
         patch("transcribe_anything.whisper.IsoEnv", FakeIsoEnv),
         patch("transcribe_anything.whisper.has_nvidia_smi", return_value=has_nvidia),
+        patch("transcribe_anything.whisper.IS_MAC", False),
     ):
         from transcribe_anything.whisper import get_environment
 


### PR DESCRIPTION
Refs #86

## Summary

- Fixes the post-merge `MacOS_Tests` failure exposed by #87's workflow branch-filter fix.
- The CUDA pyproject tests intentionally validate the non-mac NVIDIA generation path; patch the helper to simulate `IS_MAC=False` along with `has_nvidia_smi=True`.

## Test plan

- [x] `pytest -q tests\test_cuda_version_upgrade.py::TestWhisperPyprojectGeneration tests\test_cuda_version_upgrade.py::TestInsanePyprojectGeneration tests\test_whisperx_reqs.py`
- [x] `python -m ruff check tests\test_cuda_version_upgrade.py`
- [x] `python -m mypy tests\test_cuda_version_upgrade.py`
- [x] `git diff --check`