### PR TITLE
Add insane-flash backend with pinned FlashAttention wheels

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -42,7 +42,7 @@ This document outlines the architecture for adding live transcription support to
 - Producer: Audio capture thread
 - Consumer: Transcription thread
 - Use existing faster-whisper backend for speed
-- Support for all device types: cpu, cuda, insane, whisperx, mlx
+- Support for all device types: cpu, cuda, insane, insane-flash, whisperx, mlx
 
 #### 4. Hotkey Handler (`hotkey.py`)
 - Global hotkey listener (default: configurable, e.g., Ctrl+Shift+T)
@@ -156,7 +156,7 @@ LiveTranscriptionConfig:
 - Use faster-whisper backend by default
 - Implement chunk-based processing (process while recording)
 - Use VAD to avoid processing silence
-- Support all existing device modes (cpu, cuda, insane, whisperx, mlx)
+- Support all existing device modes (cpu, cuda, insane, insane-flash, whisperx, mlx)
 
 #### Challenge 4: Hotkey Conflicts
 **Solution**:
@@ -419,7 +419,7 @@ from transcribe_anything import StreamingTranscriber
 # Low-latency streaming transcriber
 transcriber = StreamingTranscriber(
     model="base",
-    device="cuda",  # cpu, cuda, insane, whisperx, mlx
+    device="cuda",  # cpu, cuda, insane, insane-flash, whisperx, mlx
     latency_mode="low",  # ultra, low, balanced, quality
     callback=lambda text: print(f">> {text}", end="", flush=True)
 )
@@ -468,7 +468,7 @@ from transcribe_anything import LiveTranscriber
 # Create transcriber
 transcriber = LiveTranscriber(
     model="base",
-    device="cuda",  # cpu, cuda, insane, whisperx, mlx
+    device="cuda",  # cpu, cuda, insane, insane-flash, whisperx, mlx
     hotkey="ctrl+shift+t",
     output_file="transcript.txt"
 )

--- a/DEV.md
+++ b/DEV.md
@@ -15,6 +15,10 @@ This project is unique in that complex dependencies for the AI models are siloed
 
 WhisperX is an additional backend exposed as `--device whisperx`; it does not replace `--device insane`.
 
+`--device insane-flash` is a separate insanely-fast-whisper environment that forces and verifies FlashAttention2. It uses `venv/insanely_fast_whisper_flash`, while normal `--device insane` continues to use `venv/insanely_fast_whisper` without requiring `flash-attn`.
+
+The flash dependency is intentionally pinned by direct wheel URL plus sha256 in `src/transcribe_anything/flash_attention_wheels.py`. Do not replace it with an unpinned PyPI `flash-attn` source dependency; unsupported tuples should fail early or get a new checked manifest entry after GPU validation.
+
 If you end up down this rabbit hole implementing a feature and want to test a backend, it's actually easy.
 
 Install the program and then see where a `.venv` is created for the backend you are

--- a/README.md
+++ b/README.md
@@ -27,6 +27,18 @@ Over 800+⭐'s because this program this app just works! Works great for windows
 - **99.9% uptime SLA** with enterprise-grade security (SOC 2, HIPAA, ISO 27001)
 - **One API for all meeting platforms** — no platform-specific integrations required
 
+### New in 4.0! (planned)
+
+**Guaranteed FlashAttention backend for CUDA users.**
+
+The new `--device insane-flash` backend keeps normal `--device insane` unchanged, but creates a separate isolated environment with pinned FlashAttention wheels. On supported NVIDIA CUDA platforms it forces the upstream insanely-fast-whisper `--flash True` path, verifies `flash_attn` and the compiled CUDA extension before transcription starts, and fails early with platform diagnostics when no controlled wheel is available.
+
+Supported first-pass wheel targets are Windows x86_64, Linux x86_64, and Linux aarch64 on Python 3.11 with `torch==2.7.0+cu128` and `flash-attn==2.8.3`. macOS is not supported for `insane-flash`; Apple Silicon users should use `--device mlx`.
+
+```bash
+transcribe-anything video.mp4 --device insane-flash --batch-size 8
+```
+
 ### New in 3.2!
 
 **Turbo Mac acceleration using the new [lightning-whisper-mlx](https://github.com/mustafaaljadery/lightning-whisper-mlx) backend.**
@@ -67,7 +79,7 @@ You can pull the docker image like so:
 
 ## About
 
-Easiest whisper implementation to install and use. Just install with `pip install transcribe-anything`. All whisper backends are executed in an isolated environment. GPU acceleration is _automatic_, using the _blazingly_ fast [insanely-fast-whisper](https://github.com/Vaibhavs10/insanely-fast-whisper) as the backend for `--device insane`. WhisperX is also available with `--device whisperx` for alignment, diarization, and word highlighting; it is additive and does not replace `--device insane`. This is the only tool to optionally produces a `speaker.json` file, representing speaker-assigned text that has been de-chunkified.
+Easiest whisper implementation to install and use. Just install with `pip install transcribe-anything`. All whisper backends are executed in an isolated environment. GPU acceleration is _automatic_, using the _blazingly_ fast [insanely-fast-whisper](https://github.com/Vaibhavs10/insanely-fast-whisper) as the backend for `--device insane`. CUDA users can choose `--device insane-flash` for a separate FlashAttention2-backed insane environment with pinned wheel artifacts. WhisperX is also available with `--device whisperx` for alignment, diarization, and word highlighting; it is additive and does not replace `--device insane`. This is the only tool to optionally produces a `speaker.json` file, representing speaker-assigned text that has been de-chunkified.
 
 Hardware acceleration on Windows/Linux `--device insane`
 
@@ -90,12 +102,15 @@ transcribe-anything https://www.youtube.com/watch?v=dQw4w9WgXcQ
 # GPU accelerated (Windows/Linux)
 transcribe-anything https://www.youtube.com/watch?v=dQw4w9WgXcQ --device insane
 
+# GPU accelerated with guaranteed FlashAttention2 where supported
+transcribe-anything https://www.youtube.com/watch?v=dQw4w9WgXcQ --device insane-flash
+
 # Mac Apple Silicon accelerated
 transcribe-anything https://www.youtube.com/watch?v=dQw4w9WgXcQ --device mlx
 
 # Advanced options (see Advanced Options section below for full details)
 transcribe-anything video.mp4 --device mlx --batch_size 16 --verbose
-transcribe-anything video.mp4 --device insane --batch-size 8 --flash True
+transcribe-anything video.mp4 --device insane-flash --batch-size 8
 ```
 
 _python api_
@@ -118,7 +133,7 @@ def transcribe(
     model: Optional[str] = None,              # tiny,small,medium,large
     task: Optional[str] = None,               # transcribe or translate
     language: Optional[str] = None,           # auto detected if none, "en" for english...
-    device: Optional[str] = None,             # cuda,cpu,insane,mlx,whisperx
+    device: Optional[str] = None,             # cuda,cpu,insane,insane-flash,mlx,whisperx
     embed: bool = False,                      # Produces a video.mp4 with the subtitles burned in.
     hugging_face_token: Optional[str] = None, # For diarization/speaker.json on supported backends
     other_args: Optional[list[str]] = None,   # Other args to be passed to to the whisper backend
@@ -143,6 +158,12 @@ Large batch sizes require more significant amounts of Nvidia GPU Ram. For a 12 G
 If you pass in `--device insane` on a cuda platform then this tool will use this state of the art version of whisper: https://github.com/Vaibhavs10/insanely-fast-whisper, which is MUCH faster and has a pipeline for speaker identification (diarization) using the `--hf_token` option.
 
 Compatible with Python 3.10 and above. Backends use an isolated environment with pinned requirements and python version.
+
+Use `--device insane-flash` when you specifically want the FlashAttention2 path. It uses a separate isolated environment (`venv/insanely_fast_whisper_flash`) with pinned `flash-attn==2.8.3` wheel artifacts for supported CUDA tuples, injects `--flash True`, and verifies FlashAttention before transcription starts. Normal `--device insane` remains the default SDPA path and does not require `flash-attn`.
+
+`insane-flash` currently supports controlled wheel candidates for Windows x86_64, Linux x86_64, and Linux aarch64 on Python 3.11 with `torch==2.7.0+cu128`. macOS is unsupported for this CUDA backend; use `--device mlx` on Apple Silicon.
+
+To prebuild the flash environment, run `transcribe-anything-init-insane-flash`.
 
 #### Speaker.json
 
@@ -218,11 +239,12 @@ Mac:
 | Backend | Device Flag | Key Arguments | Best For |
 |---------|-------------|---------------|----------|
 | **MLX** | `--device mlx` | `--batch_size`, `--verbose`, `--initial_prompt` | Mac Apple Silicon |
-| **Insanely Fast** | `--device insane` | `--batch-size`, `--hf_token`, `--flash`, `--timestamp` | Windows/Linux GPU |
+| **Insanely Fast** | `--device insane` | `--batch-size`, `--hf_token`, `--timestamp` | Windows/Linux GPU |
+| **Insane Flash** | `--device insane-flash` | `--batch-size`, `--hf_token`, `--timestamp` | CUDA GPU with verified FlashAttention2 |
 | **WhisperX** | `--device whisperx` | `--compute_type`, `--diarize`, `--batch_size`, `--align_model` | Alignment, diarization, word timing |
 | **CPU** | `--device cpu` | Standard whisper args | Universal compatibility |
 
-> **Note:** Each backend has different capabilities. MLX is optimized for Apple Silicon with a focused feature set. Insanely Fast uses a transformer-based architecture with specific options. WhisperX is an additive backend for alignment and diarization, not a replacement for `--device insane`. CPU backend supports the full range of standard OpenAI Whisper arguments.
+> **Note:** Each backend has different capabilities. MLX is optimized for Apple Silicon with a focused feature set. Insanely Fast uses a transformer-based architecture with specific options. `insane-flash` is the same backend family with verified FlashAttention2 dependencies. WhisperX is an additive backend for alignment and diarization, not a replacement for `--device insane`. CPU backend supports the full range of standard OpenAI Whisper arguments.
 
 ## Custom Prompts and Vocabulary
 
@@ -349,7 +371,7 @@ transcribe-anything video.mp4 --device insane --timestamp word   # word-level
 | Argument | Type | Default | Description |
 |----------|------|---------|-------------|
 | `--batch-size` | int | 24 | Batch size for processing. Critical for GPU memory management |
-| `--flash` | bool | false | Use Flash Attention 2 for faster processing |
+| `--flash` | bool | false | Upstream pass-through flag. Prefer `--device insane-flash` for guaranteed FlashAttention2 setup |
 | `--timestamp` | choice | chunk | Timestamp granularity: "chunk" or "word" |
 | `--hf_token` | string | None | HuggingFace token for speaker diarization |
 | `--num-speakers` | int | None | Exact number of speakers (cannot use with min/max) |
@@ -357,7 +379,7 @@ transcribe-anything video.mp4 --device insane --timestamp word   # word-level
 | `--max-speakers` | int | None | Maximum number of speakers |
 | `--diarization_model` | string | pyannote/speaker-diarization | Diarization model to use |
 
-> **Note:** The insanely-fast-whisper backend uses a different architecture than standard OpenAI Whisper. It does NOT support standard whisper arguments like `--temperature`, `--beam_size`, `--best_of`, etc. These are specific to the OpenAI implementation.
+> **Note:** The insanely-fast-whisper backend uses a different architecture than standard OpenAI Whisper. It does NOT support standard whisper arguments like `--temperature`, `--beam_size`, `--best_of`, etc. These are specific to the OpenAI implementation. Use `--device insane-flash` instead of manually adding `--flash True` when you need FlashAttention2 to be installed and verified.
 
 ## WhisperX Backend Arguments (--device whisperx)
 
@@ -437,8 +459,12 @@ transcribe-anything video.mp4 --device cpu --threads 4 --clip_timestamps "0,30"
 - Recommended for 8GB GPU: 4-8
 - Recommended for 12GB GPU: 8-12
 - Recommended for 24GB GPU: 16-24
-- Use `--flash True` for better memory efficiency
 - Start low and increase if no OOM errors
+
+**Insane Flash (`--device insane-flash`):**
+- Start with `--batch-size 4` or `--batch-size 8` on 8-12GB GPUs
+- Increase batch size only after verifying SRT timing and memory stability
+- Requires a supported CUDA FlashAttention wheel tuple; unsupported hosts fail before transcription
 
 **WhisperX Backend (`--device whisperx`):**
 - Start with `--batch_size 8` on smaller GPUs
@@ -484,8 +510,8 @@ transcribe-anything video.mp4 --device insane
 # Insane mode with custom batch size (important for GPU memory)
 transcribe-anything video.mp4 --device insane --batch-size 8
 
-# Insane mode with Flash Attention 2 for speed
-transcribe-anything video.mp4 --device insane --batch-size 12 --flash True
+# Insane Flash mode with verified FlashAttention2
+transcribe-anything video.mp4 --device insane-flash --batch-size 8
 
 # Insane mode with speaker diarization
 transcribe-anything video.mp4 --device insane --hf_token your_huggingface_token
@@ -494,7 +520,7 @@ transcribe-anything video.mp4 --device insane --hf_token your_huggingface_token
 transcribe-anything video.mp4 --device insane --timestamp word --hf_token your_token --num-speakers 3
 
 # High-performance setup with all optimizations
-transcribe-anything video.mp4 --device insane --batch-size 16 --flash True --timestamp word
+transcribe-anything video.mp4 --device insane-flash --batch-size 12 --timestamp word
 ```
 
 ### WhisperX Backend

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,4 +66,5 @@ members = ["tmp"]
 transcribe_anything = "transcribe_anything._cmd:main"
 transcribe-anything = "transcribe_anything._cmd:main"
 transcribe-anything-init-insane = "transcribe_anything.cli_init_insane:main"
+transcribe-anything-init-insane-flash = "transcribe_anything.cli_init_insane_flash:main"
 transcribe-anything-init-whisperx = "transcribe_anything.cli_init_whisperx:main"

--- a/src/transcribe_anything/_cmd.py
+++ b/src/transcribe_anything/_cmd.py
@@ -57,6 +57,8 @@ WHISPERX_FLAG_ARGS = [
     ("highlight_words", "--highlight_words"),
 ]
 
+INSANE_DEVICES = {"insane", "insane-flash"}
+
 
 def route_whisperx_args(args: argparse.Namespace, unknown: list[str]) -> None:
     """Append WhisperX-only CLI args to unknown when the WhisperX backend is selected."""
@@ -137,7 +139,7 @@ def parse_arguments() -> argparse.Namespace:
         default=None,
         choices=[None] + whisper_options["language"],
     )
-    choices = [None, "cpu", "cuda", "insane", "whisperx"]
+    choices = [None, "cpu", "cuda", "insane", "insane-flash", "whisperx"]
     if platform.system() == "Darwin":
         choices.extend(["mlx", "mps"])  # mps for backward compatibility
     parser.add_argument(
@@ -158,12 +160,12 @@ def parse_arguments() -> argparse.Namespace:
     )
     parser.add_argument(
         "--diarization_model",
-        help=("Name of the pretrained model/ checkpoint to perform diarization." + " (default: pyannote/speaker-diarization). Only works for --device insane."),
+        help=("Name of the pretrained model/ checkpoint to perform diarization." + " (default: pyannote/speaker-diarization). Only works for --device insane/insane-flash."),
         default="pyannote/speaker-diarization-3.1",
     )
     parser.add_argument(
         "--timestamp",
-        help=("Whisper supports both chunked as well as word level timestamps. (default: chunk)." + " Only works for --device insane."),
+        help=("Whisper supports both chunked as well as word level timestamps. (default: chunk)." + " Only works for --device insane/insane-flash."),
         choices=["chunk", "word"],
         default=None,
     )
@@ -288,8 +290,8 @@ def main() -> int:
     elif args.model == "large":
         print("Defaulting to large-v3 model for --model large," + " use --model large-legacy for the old model")
         args.model = "large-v3"
-    elif args.model is None and args.device == "insane":
-        print("Defaulting to large-v3 model for --device insane")
+    elif args.model is None and args.device in INSANE_DEVICES:
+        print(f"Defaulting to large-v3 model for --device {args.device}")
         args.model = "large-v3"
 
     hf_token_path = Path(user_cache_dir(), "hf_token.txt")
@@ -306,15 +308,15 @@ def main() -> int:
 
     # For now, just stuff --diarization_model and --timestamp into unknown
     if args.diarization_model:
-        if args.device != "insane":
-            print("--diarization_model only works with --device insane. Ignoring --diarization_model")
+        if args.device not in INSANE_DEVICES:
+            print("--diarization_model only works with --device insane/insane-flash. Ignoring --diarization_model")
         else:
             unknown.append("--diarization_model")
             unknown.append(args.diarization_model)
 
     if args.timestamp:
-        if args.device != "insane":
-            print("--timestamp only works with --device insane. Ignoring --timestamp")
+        if args.device not in INSANE_DEVICES:
+            print("--timestamp only works with --device insane/insane-flash. Ignoring --timestamp")
         else:
             # unknown.append(f"--timestamp {args.timestamp}")
             unknown.append("--timestamp")

--- a/src/transcribe_anything/api.py
+++ b/src/transcribe_anything/api.py
@@ -54,6 +54,7 @@ class Device(Enum):
     CPU = "cpu"
     CUDA = "cuda"
     INSANE = "insane"
+    INSANE_FLASH = "insane-flash"
     WHISPERX = "whisperx"
     MLX = "mlx"
 
@@ -72,6 +73,8 @@ class Device(Enum):
             return Device.CUDA
         if device == "insane":
             return Device.INSANE
+        if device == "insane-flash":
+            return Device.INSANE_FLASH
         if device == "whisperx":
             return Device.WHISPERX
         if device == "mlx":
@@ -189,7 +192,7 @@ def transcribe(
         model: Whisper model to use (tiny, small, medium, large, etc.)
         task: Task to perform (transcribe or translate)
         language: Language of the audio (auto-detected if None)
-        device: Device to use (cuda, cpu, insane, whisperx, mlx)
+        device: Device to use (cuda, cpu, insane, insane-flash, whisperx, mlx)
         embed: Whether to embed subtitles into video file
         hugging_face_token: Token for speaker diarization
         other_args: Additional arguments to pass to Whisper backend
@@ -243,6 +246,10 @@ def transcribe(
             print("#####################################")
             print("####### INSANE GPU MODE! ############")
             print("#####################################")
+        elif device_enum == Device.INSANE_FLASH:
+            print("#####################################")
+            print("#### INSANE FLASH GPU MODE! #########")
+            print("#####################################")
         elif device_enum == Device.WHISPERX:
             print("#####################################")
             print("######### WHISPERX MODE! ############")
@@ -269,7 +276,7 @@ def transcribe(
 
         print(f"Running whisper on {tmp_wav} (will install models on first run)")
         with tempfile.TemporaryDirectory() as tmpdir:
-            if device_enum == Device.INSANE:
+            if device_enum in (Device.INSANE, Device.INSANE_FLASH):
                 run_insanely_fast_whisper(
                     input_wav=Path(tmp_wav),
                     model=model_str,
@@ -278,6 +285,7 @@ def transcribe(
                     language=language_str,
                     hugging_face_token=hugging_face_token,
                     other_args=other_args,
+                    flash=device_enum == Device.INSANE_FLASH,
                 )
             elif device_enum == Device.WHISPERX:
                 global run_whisperx

--- a/src/transcribe_anything/cli_init_insane_flash.py
+++ b/src/transcribe_anything/cli_init_insane_flash.py
@@ -1,0 +1,27 @@
+"""Initialize the isolated insane-flash backend environment."""
+
+import logging
+import os
+import sys
+
+from transcribe_anything.insanley_fast_whisper_reqs import get_environment
+
+logger = logging.getLogger("transcribe_anything")
+logger.setLevel(logging.INFO)
+
+
+def main() -> int:
+    """Main entry point for pre-installing the insane-flash backend."""
+    print("Installing transcribe_anything (device insane-flash) environment...")
+    env = get_environment(has_nvidia=True, flash=True)
+    if sys.platform == "win32":
+        env.run(["python", "-c", "import os; print(os.getcwd())"])
+    else:
+        env.run(["pwd"])
+    print("Installing static ffmpeg...")
+    os.system("static_ffmpeg -version")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/transcribe_anything/flash_attention_wheels.py
+++ b/src/transcribe_anything/flash_attention_wheels.py
@@ -1,0 +1,171 @@
+"""Pinned FlashAttention wheel manifest for the insane-flash backend."""
+
+from __future__ import annotations
+
+import platform
+import sys
+from dataclasses import dataclass
+
+FLASH_ATTN_VERSION = "2.8.3"
+SUPPORTED_PYTHON_TAG = "cp311"
+SUPPORTED_TORCH_MINOR = "2.7"
+SUPPORTED_CUDA_TAG = "cu128"
+
+
+class UnsupportedFlashAttentionWheel(RuntimeError):
+    """Raised when no controlled FlashAttention wheel exists for a host tuple."""
+
+
+@dataclass(frozen=True)
+class FlashAttentionWheel:
+    """A checked FlashAttention wheel candidate for one platform tuple."""
+
+    system: str
+    machine: str
+    python_tag: str
+    torch_minor: str
+    cuda_tag: str
+    filename: str
+    url: str
+    sha256: str
+    source: str
+    release: str
+    primary: bool = True
+
+    @property
+    def requirement(self) -> str:
+        """Return a PEP 508 direct URL requirement with a hash fragment."""
+        return f"flash-attn @ {self.url}#sha256={self.sha256}"
+
+
+FLASH_ATTN_WHEELS: tuple[FlashAttentionWheel, ...] = (
+    FlashAttentionWheel(
+        system="windows",
+        machine="x86_64",
+        python_tag=SUPPORTED_PYTHON_TAG,
+        torch_minor=SUPPORTED_TORCH_MINOR,
+        cuda_tag=SUPPORTED_CUDA_TAG,
+        filename="flash_attn-2.8.3+cu128torch2.7-cp311-cp311-win_amd64.whl",
+        url="https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.7.11/flash_attn-2.8.3%2Bcu128torch2.7-cp311-cp311-win_amd64.whl",
+        sha256="ee22b69054b067de658e4a85183fc0d494b495770c8ff557e2d85b34f1f477fb",
+        source="mjun0812/flash-attention-prebuild-wheels",
+        release="v0.7.11",
+    ),
+    FlashAttentionWheel(
+        system="linux",
+        machine="x86_64",
+        python_tag=SUPPORTED_PYTHON_TAG,
+        torch_minor=SUPPORTED_TORCH_MINOR,
+        cuda_tag=SUPPORTED_CUDA_TAG,
+        filename="flash_attn-2.8.3+cu128torch2.7-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl",
+        url="https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.7.16/flash_attn-2.8.3%2Bcu128torch2.7-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl",
+        sha256="f6e22ca58419150a54499c6df209b9dbf51346829b959876edd3f37fae1d7a03",
+        source="mjun0812/flash-attention-prebuild-wheels",
+        release="v0.7.16",
+    ),
+    FlashAttentionWheel(
+        system="linux",
+        machine="x86_64",
+        python_tag=SUPPORTED_PYTHON_TAG,
+        torch_minor=SUPPORTED_TORCH_MINOR,
+        cuda_tag=SUPPORTED_CUDA_TAG,
+        filename="flash_attn-2.8.3+cu128torch2.7-cp311-cp311-linux_x86_64.whl",
+        url="https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.7.16/flash_attn-2.8.3%2Bcu128torch2.7-cp311-cp311-linux_x86_64.whl",
+        sha256="562ada63800388bfe9733e37feb09992d59a12a386430f40a2b119c0ff68c6ad",
+        source="mjun0812/flash-attention-prebuild-wheels",
+        release="v0.7.16",
+        primary=False,
+    ),
+    FlashAttentionWheel(
+        system="linux",
+        machine="aarch64",
+        python_tag=SUPPORTED_PYTHON_TAG,
+        torch_minor=SUPPORTED_TORCH_MINOR,
+        cuda_tag=SUPPORTED_CUDA_TAG,
+        filename="flash_attn-2.8.3+cu128torch2.7-cp311-cp311-linux_aarch64.whl",
+        url="https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.6.4/flash_attn-2.8.3%2Bcu128torch2.7-cp311-cp311-linux_aarch64.whl",
+        sha256="3ddd94bd0868905569378a716907724c3ed503c3390c57dca49a5c039be3a2ff",
+        source="mjun0812/flash-attention-prebuild-wheels",
+        release="v0.6.4",
+    ),
+)
+
+
+def current_python_tag() -> str:
+    """Return the current CPython ABI tag used by wheel filenames."""
+    return f"cp{sys.version_info.major}{sys.version_info.minor}"
+
+
+def normalize_system(system: str | None = None) -> str:
+    """Normalize OS names into manifest keys."""
+    value = (system or platform.system()).strip().lower()
+    if value in {"win32", "windows"}:
+        return "windows"
+    if value.startswith("linux"):
+        return "linux"
+    if value in {"darwin", "macos", "mac"}:
+        return "darwin"
+    return value
+
+
+def normalize_machine(machine: str | None = None) -> str:
+    """Normalize architecture names into manifest keys."""
+    value = (machine or platform.machine()).strip().lower()
+    if value in {"amd64", "x64", "x86-64"}:
+        return "x86_64"
+    if value in {"arm64", "aarch64"}:
+        return "aarch64"
+    return value
+
+
+def expected_tuple_text(
+    *,
+    system: str | None = None,
+    machine: str | None = None,
+    python_tag: str | None = None,
+    torch_minor: str = SUPPORTED_TORCH_MINOR,
+    cuda_tag: str = SUPPORTED_CUDA_TAG,
+) -> str:
+    """Return a concise tuple string for diagnostics."""
+    return f"os={normalize_system(system)} arch={normalize_machine(machine)} " f"python={python_tag or current_python_tag()} torch={torch_minor} cuda={cuda_tag}"
+
+
+def get_flash_attention_wheel(
+    *,
+    has_nvidia: bool,
+    system: str | None = None,
+    machine: str | None = None,
+    python_tag: str | None = None,
+    torch_minor: str = SUPPORTED_TORCH_MINOR,
+    cuda_tag: str = SUPPORTED_CUDA_TAG,
+) -> FlashAttentionWheel:
+    """Return the primary pinned wheel for the current supported tuple."""
+    normalized_system = normalize_system(system)
+    normalized_machine = normalize_machine(machine)
+    selected_python_tag = python_tag or current_python_tag()
+    tuple_text = expected_tuple_text(
+        system=normalized_system,
+        machine=normalized_machine,
+        python_tag=selected_python_tag,
+        torch_minor=torch_minor,
+        cuda_tag=cuda_tag,
+    )
+    if normalized_system == "darwin":
+        raise UnsupportedFlashAttentionWheel("insane-flash is not supported on macOS because this backend requires CUDA FlashAttention. " f"Use --device mlx on Apple Silicon. Tuple: {tuple_text}.")
+    if not has_nvidia:
+        raise UnsupportedFlashAttentionWheel("insane-flash requires NVIDIA CUDA hardware and nvidia-smi. " f"No controlled FlashAttention wheel selected for {tuple_text}.")
+    matches = [
+        wheel
+        for wheel in FLASH_ATTN_WHEELS
+        if wheel.system == normalized_system and wheel.machine == normalized_machine and wheel.python_tag == selected_python_tag and wheel.torch_minor == torch_minor and wheel.cuda_tag == cuda_tag
+    ]
+    primary_matches = [wheel for wheel in matches if wheel.primary]
+    if primary_matches:
+        return primary_matches[0]
+    if matches:
+        return matches[0]
+    raise UnsupportedFlashAttentionWheel(
+        "No pinned FlashAttention wheel is available for insane-flash. "
+        f"Tuple: {tuple_text}. Supported tuples are Windows x86_64, Linux x86_64, "
+        "and Linux aarch64 on Python cp311 with torch2.7/cu128."
+    )

--- a/src/transcribe_anything/insanely_fast_whisper.py
+++ b/src/transcribe_anything/insanely_fast_whisper.py
@@ -27,6 +27,83 @@ from transcribe_anything.util import print_cuda_diagnostics
 
 HERE = Path(__file__).parent
 CUDA_INFO: Optional[CudaInfo] = None
+FLASH_ATTENTION_VERIFIED = False
+
+_TRUE_VALUES = {"1", "true", "t", "yes", "y", "on"}
+_FALSE_VALUES = {"0", "false", "f", "no", "n", "off"}
+
+FLASH_ATTENTION_PROBE_CODE = r"""
+import json
+import platform
+import sys
+
+result = {
+    "python": sys.version.split()[0],
+    "platform": platform.platform(),
+}
+
+try:
+    import torch
+
+    result["torch_version"] = torch.__version__
+    result["torch_cuda"] = torch.version.cuda
+    result["cuda_available"] = bool(torch.cuda.is_available())
+    if not torch.cuda.is_available():
+        raise RuntimeError("torch.cuda.is_available() returned False")
+
+    capability = torch.cuda.get_device_capability(0)
+    result["gpu_name"] = torch.cuda.get_device_name(0)
+    result["gpu_capability"] = f"sm_{capability[0]}{capability[1]}"
+    if capability[0] < 8:
+        raise RuntimeError("FlashAttention-2 CUDA requires NVIDIA Ampere or newer (SM80+)")
+
+    import flash_attn
+    import flash_attn_2_cuda  # noqa: F401
+
+    result["flash_attn_version"] = getattr(flash_attn, "__version__", "unknown")
+    result["flash_attn_2_cuda"] = True
+
+    from transformers import AutoModelForSpeechSeq2Seq, WhisperConfig
+    from transformers.utils import is_flash_attn_2_available
+
+    result["transformers_flash_attn_2_available"] = bool(is_flash_attn_2_available())
+    if not result["transformers_flash_attn_2_available"]:
+        raise RuntimeError("Transformers reports FlashAttention2 as unavailable")
+
+    config = WhisperConfig(
+        vocab_size=64,
+        d_model=16,
+        encoder_layers=1,
+        decoder_layers=1,
+        encoder_attention_heads=2,
+        decoder_attention_heads=2,
+        encoder_ffn_dim=32,
+        decoder_ffn_dim=32,
+        num_mel_bins=80,
+        max_source_positions=16,
+        max_target_positions=16,
+        pad_token_id=0,
+        bos_token_id=1,
+        eos_token_id=2,
+        decoder_start_token_id=1,
+    )
+    model = AutoModelForSpeechSeq2Seq.from_config(
+        config,
+        attn_implementation="flash_attention_2",
+        torch_dtype=torch.float16,
+    ).to("cuda")
+    result["whisper_attn_implementation"] = getattr(model.config, "_attn_implementation", None)
+    if result["whisper_attn_implementation"] != "flash_attention_2":
+        raise RuntimeError(
+            "Whisper model did not select flash_attention_2; "
+            f"got {result['whisper_attn_implementation']!r}"
+        )
+    print(json.dumps(result, sort_keys=True))
+except Exception as exc:
+    result["error"] = repr(exc)
+    print(json.dumps(result, sort_keys=True), file=sys.stderr)
+    raise
+"""
 
 
 def _k2_stub_root() -> Path:
@@ -56,6 +133,87 @@ def _prepare_subprocess_env(base_env: dict[str, str]) -> dict[str, str]:
         parts.append(stub)
     env["PYTHONPATH"] = os.pathsep.join(parts)
     return env
+
+
+def _split_flag_value(arg: str) -> tuple[str, str | None]:
+    """Split --flag=value args while preserving plain flags."""
+    if arg.startswith("--") and "=" in arg:
+        flag, value = arg.split("=", 1)
+        return flag, value
+    return arg, None
+
+
+def _bool_arg_value(value: str | None) -> bool:
+    """Normalize a CLI boolean value."""
+    if value is None:
+        return True
+    normalized = value.strip().lower()
+    if normalized in _TRUE_VALUES:
+        return True
+    if normalized in _FALSE_VALUES:
+        return False
+    raise ValueError(f"Expected a boolean value for --flash, got {value!r}")
+
+
+def _prepare_insane_args(other_args: list[str] | None, *, force_flash: bool) -> list[str]:
+    """Return backend args, forcing --flash True for the insane-flash backend."""
+    args = [str(arg) for arg in (other_args or [])]
+    if not force_flash:
+        return args
+
+    prepared: list[str] = []
+    index = 0
+    saw_flash = False
+    while index < len(args):
+        raw_arg = args[index]
+        flag, explicit_value = _split_flag_value(raw_arg)
+        if flag != "--flash":
+            prepared.append(raw_arg)
+            index += 1
+            continue
+
+        saw_flash = True
+        if explicit_value is not None:
+            value = explicit_value
+            index += 1
+        elif index + 1 < len(args) and not args[index + 1].startswith("-"):
+            value = args[index + 1]
+            index += 2
+        else:
+            value = None
+            index += 1
+        if not _bool_arg_value(value):
+            raise ValueError("--device insane-flash requires FlashAttention; remove '--flash False' or use --device insane.")
+
+    if saw_flash:
+        sys.stderr.write("Normalizing --flash True for --device insane-flash.\n")
+    prepared.extend(["--flash", "True"])
+    return prepared
+
+
+def verify_flash_attention_available(iso_env: Any) -> None:
+    """Verify that the flash env can import and select FlashAttention2."""
+    global FLASH_ATTENTION_VERIFIED  # pylint: disable=global-statement
+    if FLASH_ATTENTION_VERIFIED:
+        return
+
+    result = iso_env.run(
+        ["python", "-c", FLASH_ATTENTION_PROBE_CODE],
+        shell=False,
+        universal_newlines=True,
+        encoding="utf-8",
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    stdout = (result.stdout or "").strip()
+    stderr = (result.stderr or "").strip()
+    if result.returncode != 0:
+        details = "\n".join(part for part in [stdout, stderr] if part)
+        raise RuntimeError(f"insane-flash FlashAttention capability probe failed:\n{details}")
+    if stdout:
+        sys.stderr.write(f"insane-flash FlashAttention probe passed: {stdout}\n")
+    FLASH_ATTENTION_VERIFIED = True
 
 
 def get_cuda_info() -> CudaInfo:
@@ -227,11 +385,15 @@ def run_insanely_fast_whisper(
     language: str,
     hugging_face_token: str | None = None,
     other_args: list[str] | None = None,
+    flash: bool = False,
 ) -> None:
     """Runs insanely fast whisper."""
     # ffmpeg paths have to be installed or else the backend tool will fail.
     static_ffmpeg.add_paths()
-    iso_env = get_environment()
+    iso_env = get_environment(flash=flash)
+    backend_args = _prepare_insane_args(other_args, force_flash=flash)
+    if flash:
+        verify_flash_attention_available(iso_env)
     env = _prepare_subprocess_env(dict(os.environ))
     if sys.platform == "darwin":
         # Attempts fixed recommended for the mps machines. This seems
@@ -271,28 +433,28 @@ def run_insanely_fast_whisper(
     if hugging_face_token:
         cmd_list += ["--hf-token", hugging_face_token]
         # remove --hf-token from other_args if it's there.
-        if other_args and "--hf-token" in other_args:
-            idx = other_args.index("--hf-token")
+        if "--hf-token" in backend_args:
+            idx = backend_args.index("--hf-token")
             idx2 = idx + 1
-            other_args.pop(idx2)
-            other_args.pop(idx)
+            backend_args.pop(idx2)
+            backend_args.pop(idx)
     if language:
         cmd_list += ["--language", language]
 
     batch_size: int | None = None
-    if other_args:
+    if backend_args:
         # Check if the other_args contains --batch-size and remove it.
-        if "--batch-size" in other_args:
-            idx = other_args.index("--batch-size")
+        if "--batch-size" in backend_args:
+            idx = backend_args.index("--batch-size")
             idx2 = idx + 1
-            batch_size = int(other_args[idx2])
-            other_args.pop(idx2)
-            other_args.pop(idx)
+            batch_size = int(backend_args[idx2])
+            backend_args.pop(idx2)
+            backend_args.pop(idx)
     batch_size = get_batch_size() or batch_size
     if batch_size is not None:
         cmd_list += ["--batch-size", f"{batch_size}"]
-    if other_args:
-        cmd_list.extend(other_args)
+    if backend_args:
+        cmd_list.extend(backend_args)
     # Remove the empty strings.
     cmd_list = [x.strip() for x in cmd_list if x.strip()]
     cmd = subprocess.list2cmdline(cmd_list)

--- a/src/transcribe_anything/insanley_fast_whisper_reqs.py
+++ b/src/transcribe_anything/insanley_fast_whisper_reqs.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from iso_env import IsoEnv, IsoEnvArgs, PyProjectToml  # type: ignore
 
+from transcribe_anything.flash_attention_wheels import SUPPORTED_PYTHON_TAG, get_flash_attention_wheel
 from transcribe_anything.util import has_nvidia_smi
 
 HERE = Path(__file__).parent
@@ -16,6 +17,9 @@ TENSOR_VERSION = "2.7.0"
 CUDA_VERSION = "cu128"
 TENSOR_CUDA_VERSION = f"{TENSOR_VERSION}+{CUDA_VERSION}"
 EXTRA_INDEX_URL = f"https://download.pytorch.org/whl/{CUDA_VERSION}"
+PYTHON_VERSION = "==3.11.*"
+INSANE_ENV_NAME = "insanely_fast_whisper"
+INSANE_FLASH_ENV_NAME = "insanely_fast_whisper_flash"
 
 
 def get_current_python_version() -> str:
@@ -64,17 +68,15 @@ def _get_reqs_generic(has_nvidia: bool) -> list[str]:
     return content_lines
 
 
-def get_environment(has_nvidia: bool | None = None) -> IsoEnv:
-    """Returns the environment."""
-    venv_dir = HERE / "venv" / "insanely_fast_whisper"
-    # has_nvidia = has_nvidia_smi()
-    if has_nvidia is None:
-        has_nvidia = has_nvidia_smi()
-    # We used to use pip to compile args, but it was hurting developement so now
-    # we always use the generic requirements.
+def build_pyproject_toml(has_nvidia: bool, flash: bool = False) -> str:
+    """Build the uv pyproject content for the isolated insane backend env."""
     dep_lines = _get_reqs_generic(has_nvidia)
+    if flash:
+        wheel = get_flash_attention_wheel(has_nvidia=has_nvidia, python_tag=SUPPORTED_PYTHON_TAG)
+        dep_lines.append(wheel.requirement)
     # filter out empty lines
     dep_lines = [line.strip() for line in dep_lines if line.strip()]
+
     content_lines: list[str] = []
 
     content_lines.append("[build-system]")
@@ -85,7 +87,7 @@ def get_environment(has_nvidia: bool | None = None) -> IsoEnv:
     content_lines.append("[project]")
     content_lines.append('name = "project"')
     content_lines.append('version = "0.1.0"')
-    content_lines.append('requires-python = "==3.11.*"')
+    content_lines.append(f'requires-python = "{PYTHON_VERSION}"')
     content_lines.append("dependencies = [")
     for dep in dep_lines:
         content_lines.append(f'  "{dep}",')
@@ -111,8 +113,16 @@ def get_environment(has_nvidia: bool | None = None) -> IsoEnv:
         content_lines.append(f'url = "{EXTRA_INDEX_URL}"')
         content_lines.append("explicit = true")
 
-    content = "\n".join(content_lines)
+    return "\n".join(content_lines)
 
+
+def get_environment(has_nvidia: bool | None = None, flash: bool = False) -> IsoEnv:
+    """Returns the isolated insane or insane-flash environment."""
+    env_name = INSANE_FLASH_ENV_NAME if flash else INSANE_ENV_NAME
+    venv_dir = HERE / "venv" / env_name
+    if has_nvidia is None:
+        has_nvidia = has_nvidia_smi()
+    content = build_pyproject_toml(has_nvidia=has_nvidia, flash=flash)
     build_info = PyProjectToml(content)
     args = IsoEnvArgs(venv_path=venv_dir, build_info=build_info)
     env = IsoEnv(args)

--- a/tests/test_insane_flash_cmd_arg.py
+++ b/tests/test_insane_flash_cmd_arg.py
@@ -1,0 +1,232 @@
+"""insane-flash CLI/API routing and backend argument tests."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest import mock
+
+import pytest
+
+WHISPER_OPTIONS = {
+    "task": ["transcribe", "translate"],
+    "language": ["en", "fr", "None"],
+}
+
+SAMPLE_INSANE_JSON = {"text": "Hello", "chunks": [{"timestamp": [0.0, 1.0], "text": " Hello"}]}
+
+
+def _value_after(cmd: list[str], option: str) -> str:
+    idx = cmd.index(option)
+    return cmd[idx + 1]
+
+
+def test_device_enum_accepts_insane_flash() -> None:
+    from transcribe_anything.api import Device
+
+    assert str(Device.INSANE_FLASH) == "insane-flash"
+    assert Device.from_str("insane-flash") is Device.INSANE_FLASH
+
+
+def test_cli_parser_accepts_insane_flash_and_preserves_backend_args() -> None:
+    from transcribe_anything import _cmd
+
+    argv = [
+        "transcribe-anything",
+        "sample.wav",
+        "--device",
+        "insane-flash",
+        "--model",
+        "tiny",
+        "--language",
+        "en",
+        "--timestamp",
+        "word",
+        "--batch-size",
+        "2",
+    ]
+    with (
+        mock.patch.object(sys, "argv", argv),
+        mock.patch.object(_cmd, "get_whisper_options", return_value=WHISPER_OPTIONS),
+        mock.patch.object(_cmd, "get_computing_device", return_value="cpu"),
+    ):
+        args = _cmd.parse_arguments()
+
+    assert args.device == "insane-flash"
+    assert args.timestamp == "word"
+    assert args.unknown == ["--batch-size", "2"]
+
+
+def test_cli_main_routes_insane_flash_to_api_and_forwards_insane_args(tmp_path: Path) -> None:
+    from transcribe_anything import _cmd, api
+
+    calls: list[dict[str, Any]] = []
+
+    def fake_transcribe(**kwargs: Any) -> str:
+        calls.append(kwargs)
+        return str(kwargs["output_dir"] or "out")
+
+    argv = [
+        "transcribe-anything",
+        "sample.wav",
+        "--device",
+        "insane-flash",
+        "--model",
+        "tiny",
+        "--language",
+        "en",
+        "--timestamp",
+        "word",
+        "--batch-size",
+        "8",
+    ]
+    with (
+        mock.patch.object(sys, "argv", argv),
+        mock.patch.object(_cmd, "get_whisper_options", return_value=WHISPER_OPTIONS),
+        mock.patch.object(_cmd, "get_computing_device", return_value="cpu"),
+        mock.patch.object(_cmd, "user_cache_dir", return_value=str(tmp_path)),
+        mock.patch.dict("os.environ", {}, clear=True),
+        mock.patch.object(api, "transcribe", fake_transcribe),
+    ):
+        assert _cmd.main() == 0
+
+    assert len(calls) == 1
+    assert calls[0]["device"] == "insane-flash"
+    assert calls[0]["model"] == "tiny"
+    assert calls[0]["language"] == "en"
+    assert calls[0]["other_args"] == ["--batch-size", "8", "--timestamp", "word"]
+
+
+def test_api_routes_device_insane_flash_to_insane_backend_with_flash(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from transcribe_anything import api
+
+    input_file = tmp_path / "input.mp4"
+    input_file.write_bytes(b"fake mp4")
+    temp_wav = tmp_path / "input.wav"
+    output_dir = tmp_path / "out"
+    calls: list[dict[str, Any]] = []
+
+    def fake_fetch_audio(_url_or_file: str, wav_path: str) -> None:
+        Path(wav_path).write_bytes(b"fake wav")
+
+    def fake_run_insane(**kwargs: Any) -> None:
+        calls.append(kwargs)
+        backend_dir = Path(kwargs["output_dir"])
+        backend_dir.mkdir(parents=True, exist_ok=True)
+        (backend_dir / "out.srt").write_text("1\n00:00:00,000 --> 00:00:01,000\nHello\n\n", encoding="utf-8")
+        (backend_dir / "out.vtt").write_text("WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nHello\n", encoding="utf-8")
+        (backend_dir / "out.txt").write_text("Hello\n", encoding="utf-8")
+        (backend_dir / "out.json").write_text(json.dumps(SAMPLE_INSANE_JSON), encoding="utf-8")
+
+    def fail_backend(*_args: Any, **_kwargs: Any) -> None:
+        raise AssertionError("device='insane-flash' should route only to the insane backend")
+
+    monkeypatch.setattr(api.static_ffmpeg, "add_paths", lambda: None)
+    monkeypatch.setattr(api, "make_temp_wav", lambda: str(temp_wav))
+    monkeypatch.setattr(api, "fetch_audio", fake_fetch_audio)
+    monkeypatch.setattr(api, "run_insanely_fast_whisper", fake_run_insane)
+    monkeypatch.setattr(api, "run_whisper", fail_backend)
+    monkeypatch.setattr(api, "run_whisperx", fail_backend, raising=False)
+    monkeypatch.setattr(api, "run_whisper_mac_mlx", fail_backend)
+
+    result = api.transcribe(
+        url_or_file=str(input_file),
+        output_dir=str(output_dir),
+        model="tiny",
+        task="transcribe",
+        language="en",
+        device="insane-flash",
+        other_args=["--batch-size", "4"],
+    )
+
+    assert result == str(output_dir.resolve())
+    assert len(calls) == 1
+    assert calls[0]["flash"] is True
+    assert calls[0]["other_args"] == ["--batch-size", "4"]
+    for filename in ["out.srt", "out.vtt", "out.txt", "out.json"]:
+        assert (output_dir / filename).exists()
+
+
+def test_prepare_insane_args_forces_flash_true_without_mutating_input() -> None:
+    from transcribe_anything.insanely_fast_whisper import _prepare_insane_args
+
+    args = ["--batch-size", "4", "--flash", "True"]
+    prepared = _prepare_insane_args(args, force_flash=True)
+
+    assert args == ["--batch-size", "4", "--flash", "True"]
+    assert prepared == ["--batch-size", "4", "--flash", "True"]
+
+
+def test_prepare_insane_args_rejects_flash_false() -> None:
+    from transcribe_anything.insanely_fast_whisper import _prepare_insane_args
+
+    with pytest.raises(ValueError, match="requires FlashAttention"):
+        _prepare_insane_args(["--flash=False"], force_flash=True)
+
+
+def test_run_insanely_fast_whisper_uses_flash_env_and_forces_flash_arg(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    import transcribe_anything.insanely_fast_whisper as insane
+
+    input_wav = tmp_path / "input.wav"
+    input_wav.write_bytes(b"fake wav")
+    output_dir = tmp_path / "backend"
+    env_calls: list[bool] = []
+
+    class FakeProc:
+        def poll(self) -> int:
+            return 0
+
+        def wait(self) -> int:
+            return 0
+
+    class FakeEnv:
+        def __init__(self) -> None:
+            self.commands: list[list[str]] = []
+
+        def open_proc(self, cmd: list[Any], **_kwargs: Any) -> FakeProc:
+            cmd_list = [str(arg) for arg in cmd]
+            self.commands.append(cmd_list)
+            transcript_path = Path(_value_after(cmd_list, "--transcript-path"))
+            transcript_path.parent.mkdir(parents=True, exist_ok=True)
+            transcript_path.write_text(json.dumps(SAMPLE_INSANE_JSON), encoding="utf-8")
+            return FakeProc()
+
+        def run(self, cmd: list[Any], **_kwargs: Any) -> SimpleNamespace:
+            self.commands.append([str(arg) for arg in cmd])
+            return SimpleNamespace(returncode=0, stdout="{}", stderr="")
+
+    fake_env = FakeEnv()
+
+    def fake_get_environment(*, flash: bool = False, has_nvidia: bool | None = None) -> FakeEnv:
+        del has_nvidia
+        env_calls.append(flash)
+        return fake_env
+
+    monkeypatch.setattr(insane.static_ffmpeg, "add_paths", lambda: None)
+    monkeypatch.setattr(insane, "get_environment", fake_get_environment)
+    monkeypatch.setattr(insane, "verify_flash_attention_available", lambda _env: None)
+    monkeypatch.setattr(insane, "get_device_id", lambda: "0")
+    monkeypatch.setattr(insane, "get_batch_size", lambda: None)
+    monkeypatch.setattr(insane, "get_wave_duration", lambda _path: 1.0)
+
+    insane.run_insanely_fast_whisper(
+        input_wav=input_wav,
+        model="tiny",
+        output_dir=output_dir,
+        task="transcribe",
+        language="en",
+        other_args=["--batch-size", "4"],
+        flash=True,
+    )
+
+    assert env_calls == [True]
+    cmd = fake_env.commands[0]
+    assert cmd[0] == "insanely-fast-whisper"
+    assert _value_after(cmd, "--batch-size") == "4"
+    assert _value_after(cmd, "--flash") == "True"
+    assert (output_dir / "out.srt").exists()
+    assert (output_dir / "out.vtt").exists()
+    assert (output_dir / "out.txt").exists()

--- a/tests/test_insane_flash_reqs.py
+++ b/tests/test_insane_flash_reqs.py
@@ -1,0 +1,117 @@
+"""Unit tests for the isolated insane-flash backend requirements."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest import mock
+
+import pytest
+
+from transcribe_anything.flash_attention_wheels import (
+    FLASH_ATTN_VERSION,
+    UnsupportedFlashAttentionWheel,
+    get_flash_attention_wheel,
+)
+
+
+def test_windows_flash_attention_wheel_candidate_is_pinned() -> None:
+    wheel = get_flash_attention_wheel(has_nvidia=True, system="Windows", machine="AMD64", python_tag="cp311")
+
+    assert FLASH_ATTN_VERSION == "2.8.3"
+    assert wheel.filename == "flash_attn-2.8.3+cu128torch2.7-cp311-cp311-win_amd64.whl"
+    assert wheel.sha256 == "ee22b69054b067de658e4a85183fc0d494b495770c8ff557e2d85b34f1f477fb"
+    assert "mjun0812/flash-attention-prebuild-wheels" in wheel.url
+    assert wheel.requirement.startswith("flash-attn @ https://")
+    assert wheel.requirement.endswith(f"#sha256={wheel.sha256}")
+
+
+def test_linux_x86_flash_attention_uses_manylinux_primary_wheel() -> None:
+    wheel = get_flash_attention_wheel(has_nvidia=True, system="Linux", machine="x86_64", python_tag="cp311")
+
+    assert "manylinux_2_24_x86_64.manylinux_2_28_x86_64" in wheel.filename
+    assert wheel.sha256 == "f6e22ca58419150a54499c6df209b9dbf51346829b959876edd3f37fae1d7a03"
+    assert wheel.primary is True
+
+
+def test_linux_aarch64_flash_attention_wheel_candidate_is_pinned() -> None:
+    wheel = get_flash_attention_wheel(has_nvidia=True, system="Linux", machine="aarch64", python_tag="cp311")
+
+    assert wheel.filename == "flash_attn-2.8.3+cu128torch2.7-cp311-cp311-linux_aarch64.whl"
+    assert wheel.sha256 == "3ddd94bd0868905569378a716907724c3ed503c3390c57dca49a5c039be3a2ff"
+
+
+def test_macos_flash_attention_is_unsupported() -> None:
+    with pytest.raises(UnsupportedFlashAttentionWheel, match="not supported on macOS"):
+        get_flash_attention_wheel(has_nvidia=True, system="Darwin", machine="arm64", python_tag="cp311")
+
+
+def test_cpu_flash_attention_is_unsupported_with_actionable_tuple() -> None:
+    with pytest.raises(UnsupportedFlashAttentionWheel, match="NVIDIA CUDA"):
+        get_flash_attention_wheel(has_nvidia=False, system="Linux", machine="x86_64", python_tag="cp311")
+
+
+def test_insane_flash_pyproject_contains_direct_wheel_hash() -> None:
+    from transcribe_anything import flash_attention_wheels
+    from transcribe_anything.insanley_fast_whisper_reqs import build_pyproject_toml
+
+    with (
+        mock.patch.object(flash_attention_wheels.platform, "system", return_value="Windows"),
+        mock.patch.object(flash_attention_wheels.platform, "machine", return_value="AMD64"),
+        mock.patch.object(flash_attention_wheels, "current_python_tag", return_value="cp311"),
+    ):
+        content = build_pyproject_toml(has_nvidia=True, flash=True)
+
+    assert "flash-attn @ https://github.com/mjun0812/flash-attention-prebuild-wheels" in content
+    assert "#sha256=ee22b69054b067de658e4a85183fc0d494b495770c8ff557e2d85b34f1f477fb" in content
+    assert "torch==2.7.0+cu128" in content
+    assert "torchaudio==2.7.0+cu128" in content
+    assert "https://download.pytorch.org/whl/cu128" in content
+
+
+def test_non_flash_insane_pyproject_does_not_install_flash_attention() -> None:
+    from transcribe_anything.insanley_fast_whisper_reqs import build_pyproject_toml
+
+    content = build_pyproject_toml(has_nvidia=True, flash=False)
+
+    assert "flash-attn" not in content
+
+
+def test_get_environment_uses_dedicated_flash_venv() -> None:
+    import transcribe_anything.insanley_fast_whisper_reqs as reqs
+    from transcribe_anything import flash_attention_wheels
+
+    captured: dict[str, Any] = {}
+
+    class FakePyProjectToml:
+        def __init__(self, content: str) -> None:
+            captured["content"] = content
+            self.content = content
+
+    class FakeIsoEnvArgs:
+        def __init__(self, venv_path: Path, build_info: Any) -> None:
+            captured["venv_path"] = venv_path
+            captured["build_info"] = build_info
+            self.venv_path = venv_path
+            self.build_info = build_info
+
+    class FakeIsoEnv:
+        def __init__(self, args: Any) -> None:
+            captured["args"] = args
+            self.args = args
+
+    with (
+        mock.patch.object(reqs, "PyProjectToml", FakePyProjectToml),
+        mock.patch.object(reqs, "IsoEnvArgs", FakeIsoEnvArgs),
+        mock.patch.object(reqs, "IsoEnv", FakeIsoEnv),
+        mock.patch.object(flash_attention_wheels.platform, "system", return_value="Windows"),
+        mock.patch.object(flash_attention_wheels.platform, "machine", return_value="AMD64"),
+        mock.patch.object(flash_attention_wheels, "current_python_tag", return_value="cp311"),
+    ):
+        env = reqs.get_environment(has_nvidia=True, flash=True)
+
+    assert isinstance(env, FakeIsoEnv)
+    venv_path = Path(captured["venv_path"])
+    assert venv_path.name == "insanely_fast_whisper_flash"
+    assert "venv" in venv_path.parts
+    assert "flash-attn @" in captured["content"]

--- a/tests/test_insane_vs_cuda_longform_timestamps.py
+++ b/tests/test_insane_vs_cuda_longform_timestamps.py
@@ -29,9 +29,11 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shutil
 import subprocess
 import tempfile
+import time
 import unittest
 from pathlib import Path
 
@@ -43,6 +45,7 @@ ASSETS = HERE.parent / "src" / "transcribe_anything" / "assets"
 SAMPLE_MP3 = ASSETS / "sample.mp3"
 
 CAN_RUN_TEST = has_nvidia_smi() and not is_mac() and SAMPLE_MP3.is_file()
+RUN_INSANE_FLASH_TEST = os.environ.get("TRANSCRIBE_ANYTHING_TEST_INSANE_FLASH", "").strip().lower() in {"1", "true", "yes", "on"}
 
 # Number of loops of the ~10 s sample.mp3 to concatenate. Four copies
 # put us well past the 30-s chunk boundary that triggers the upstream bug.
@@ -124,6 +127,15 @@ def _last_end_timestamp_from_insane_json(path: Path) -> float:
     raise AssertionError(f"no closed-end chunk in insane out.json: {chunks}")
 
 
+def _last_end_timestamp_from_srt(path: Path) -> float:
+    text = path.read_text(encoding="utf-8")
+    matches = re.findall(r"-->\s+(\d{2}):(\d{2}):(\d{2}),(\d{3})", text)
+    if not matches:
+        raise AssertionError(f"No SRT timestamp end found in {path}:\n{text}")
+    hours, minutes, seconds, millis = matches[-1]
+    return (float(hours) * 3600.0) + (float(minutes) * 60.0) + float(seconds) + (float(millis) / 1000.0)
+
+
 @unittest.skipUnless(CAN_RUN_TEST, "Requires NVIDIA (not on Mac) and bundled sample.mp3")
 class LongformTimestampAgreementTester(unittest.TestCase):
     """Pin down that the two backends agree on the end of long audio."""
@@ -142,17 +154,21 @@ class LongformTimestampAgreementTester(unittest.TestCase):
 
             cuda_out = workdir / "out_cuda"
             insane_out = workdir / "out_insane"
+            insane_flash_out = workdir / "out_insane_flash"
+            runtimes: dict[str, float] = {}
 
             # Clean before each backend run in case a previous attempt
             # left stale artifacts.
             shutil.rmtree(cuda_out, ignore_errors=True)
             shutil.rmtree(insane_out, ignore_errors=True)
+            shutil.rmtree(insane_flash_out, ignore_errors=True)
 
             # Use the public transcribe() API rather than the low-level
             # run_whisper / run_insanely_fast_whisper helpers, because
             # transcribe() handles the per-backend output-file renaming
             # (openai-whisper writes <input_stem>.json; transcribe()
             # renames everything to out.json/out.srt/etc.).
+            start = time.perf_counter()
             transcribe(
                 url_or_file=str(long_wav),
                 output_dir=str(cuda_out),
@@ -161,6 +177,9 @@ class LongformTimestampAgreementTester(unittest.TestCase):
                 language="en",
                 device="cuda",
             )
+            runtimes["cuda"] = time.perf_counter() - start
+
+            start = time.perf_counter()
             transcribe(
                 url_or_file=str(long_wav),
                 output_dir=str(insane_out),
@@ -169,9 +188,12 @@ class LongformTimestampAgreementTester(unittest.TestCase):
                 language="en",
                 device="insane",
             )
+            runtimes["insane"] = time.perf_counter() - start
 
             cuda_last = _last_end_timestamp_from_whisper_json(cuda_out / "out.json")
             insane_last = _last_end_timestamp_from_insane_json(insane_out / "out.json")
+            cuda_srt_last = _last_end_timestamp_from_srt(cuda_out / "out.srt")
+            insane_srt_last = _last_end_timestamp_from_srt(insane_out / "out.srt")
 
             # Each backend's last timestamp should bracket the true duration.
             self.assertGreaterEqual(
@@ -210,6 +232,49 @@ class LongformTimestampAgreementTester(unittest.TestCase):
                     "decoding offset bug is back; verify transformers>=4.53.0 is actually installed."
                 ),
             )
+            self.assertAlmostEqual(cuda_last, cuda_srt_last, delta=LAST_TIMESTAMP_TOLERANCE_S)
+            self.assertAlmostEqual(insane_last, insane_srt_last, delta=LAST_TIMESTAMP_TOLERANCE_S)
+
+            if RUN_INSANE_FLASH_TEST:
+                start = time.perf_counter()
+                transcribe(
+                    url_or_file=str(long_wav),
+                    output_dir=str(insane_flash_out),
+                    model="tiny",
+                    task="transcribe",
+                    language="en",
+                    device="insane-flash",
+                )
+                runtimes["insane-flash"] = time.perf_counter() - start
+
+                insane_flash_last = _last_end_timestamp_from_insane_json(insane_flash_out / "out.json")
+                insane_flash_srt_last = _last_end_timestamp_from_srt(insane_flash_out / "out.srt")
+
+                self.assertGreaterEqual(
+                    insane_flash_last,
+                    wav_duration - WAV_DURATION_LOWER_SLACK_S,
+                    msg=f"insane-flash last={insane_flash_last:.2f}s far below wav_duration={wav_duration:.2f}s",
+                )
+                self.assertLessEqual(
+                    insane_flash_last,
+                    wav_duration + WAV_DURATION_UPPER_SLACK_S,
+                    msg=f"insane-flash last={insane_flash_last:.2f}s overshot wav_duration={wav_duration:.2f}s",
+                )
+                self.assertAlmostEqual(
+                    cuda_last,
+                    insane_flash_last,
+                    delta=LAST_TIMESTAMP_TOLERANCE_S,
+                    msg=(f"cuda last={cuda_last:.2f}s vs insane-flash last={insane_flash_last:.2f}s " f"differ by more than {LAST_TIMESTAMP_TOLERANCE_S}s"),
+                )
+                self.assertAlmostEqual(
+                    insane_last,
+                    insane_flash_last,
+                    delta=LAST_TIMESTAMP_TOLERANCE_S,
+                    msg=(f"insane last={insane_last:.2f}s vs insane-flash last={insane_flash_last:.2f}s " f"differ by more than {LAST_TIMESTAMP_TOLERANCE_S}s"),
+                )
+                self.assertAlmostEqual(insane_flash_last, insane_flash_srt_last, delta=LAST_TIMESTAMP_TOLERANCE_S)
+
+            print("Long-form backend runtimes:", {name: round(value, 2) for name, value in runtimes.items()})
 
 
 if __name__ == "__main__":

--- a/tests/test_whisperx_reqs.py
+++ b/tests/test_whisperx_reqs.py
@@ -18,6 +18,7 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 HEAVY_BACKEND_DEPS = {
     "ctranslate2",
+    "flash-attn",
     "faster-whisper",
     "pyannote.audio",
     "torch",


### PR DESCRIPTION
﻿Closes #89.

## Summary
- Adds `--device insane-flash` as a separate insanely-fast-whisper backend option without changing normal `--device insane` behavior.
- Creates a dedicated `venv/insanely_fast_whisper_flash` environment with pinned `flash-attn==2.8.3` direct wheel URLs and sha256 hashes for controlled CUDA tuples.
- Forces upstream `--flash True` only for `insane-flash`, verifies `flash_attn`, `flash_attn_2_cuda`, CUDA availability, SM80+, Transformers FlashAttention2 support, and a tiny Whisper FlashAttention2 model before transcription starts.
- Adds CLI/API routing, a `transcribe-anything-init-insane-flash` prebuild command, docs/release notes, and targeted unit/integration coverage.

## Platform support
- Supported pinned wheel targets: Windows x86_64, Linux x86_64, and Linux aarch64 on Python 3.11 with `torch==2.7.0+cu128` and `flash-attn==2.8.3`.
- macOS is intentionally unsupported for this CUDA FlashAttention backend; Apple Silicon users should use `--device mlx`.

## Validation
- `bash ./lint` passed. It temporarily formatted unrelated files during the run; those unrelated edits were restored before commit.
- `PYTHONPATH=src python -m pytest tests/test_insane_flash_reqs.py tests/test_insane_flash_cmd_arg.py tests/test_cuda_version_upgrade.py tests/test_transformers_version_floor.py tests/test_insanely_fast_whisper_cusparselt.py tests/test_k2_stub.py tests/test_whisperx_reqs.py -q` -> 70 passed.
- `PYTHONPATH=src python -m pytest tests/test_insane_flash_reqs.py tests/test_cuda_version_upgrade.py tests/test_install_insanley_fast_whisper_reqs.py -q` -> 49 passed.
- Windows GPU probe passed on RTX 3060 / SM86 with Python 3.11.5, torch 2.7.0+cu128, CUDA 12.8, flash_attn 2.8.3, compiled `flash_attn_2_cuda`, Transformers FlashAttention2, and a tiny Whisper model selecting `flash_attention_2`.
- Windows API smoke with `device='insane-flash'`, model `tiny`, language `en`, and `--batch-size 1` produced `out.json`, `out.srt`, `out.txt`, and `out.vtt`.
- Windows long-form timestamp check with `TRANSCRIBE_ANYTHING_TEST_INSANE_FLASH=1` passed; runtimes were cuda 9.73s, insane 30.38s, insane-flash 24.39s.
- Linux GPU Docker confirmed NVIDIA access on RTX 3060 / SM86, built the flash environment through `transcribe-anything-init-insane-flash`, and successfully ran CLI and API smokes with `--device insane-flash`; Linux probe passed with Python 3.11.12, torch 2.7.0+cu128, CUDA 12.8, flash_attn 2.8.3, compiled `flash_attn_2_cuda`, and Transformers FlashAttention2.
- Full `PYTHONPATH=src python -m pytest --tb=short -q` was attempted but timed out after 10 minutes because heavy GPU/backend integration tests do not emit progress under `-q`; no failure was observed before timeout.
