### PR TITLE
Make Docker backend prebuild opt-in

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,11 +20,23 @@ COPY . .
 RUN chmod +x entrypoint.sh && dos2unix entrypoint.sh
 
 # Install transcribe-anything in editable mode
-RUN pip install -e .
+RUN pip install --no-cache-dir -e .
 
-# Pre-initialize the insane whisper environment (downloads dependencies)
-# NOTE: GPU is not available during build, so shared library checks are skipped
-RUN transcribe-anything-init-insane
+# Keep the default image lean. Backend environments are built on first use unless
+# PREBUILD_BACKENDS is set to one of: insane, insane-flash, both, all.
+# NOTE: GPU is not available during build, so runtime CUDA checks are skipped.
+ARG PREBUILD_BACKENDS=none
+RUN set -eux; \
+    prebuild_insane() { UV_CACHE_DIR=/tmp/uv-cache transcribe-anything-init-insane; }; \
+    prebuild_insane_flash() { UV_CACHE_DIR=/tmp/uv-cache transcribe-anything-init-insane-flash; }; \
+    case "$PREBUILD_BACKENDS" in \
+        none|"") ;; \
+        insane) prebuild_insane ;; \
+        insane-flash) prebuild_insane_flash ;; \
+        insane,insane-flash|insane-flash,insane|both|all) prebuild_insane; prebuild_insane_flash ;; \
+        *) echo "Unsupported PREBUILD_BACKENDS=$PREBUILD_BACKENDS"; exit 1 ;; \
+    esac; \
+    rm -rf /root/.cache/pip /root/.cache/uv /tmp/uv-cache /tmp/*
 
 ENTRYPOINT ["/app/entrypoint.sh"]
 CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -218,7 +218,23 @@ pip install transcribe-anything
 
 # Docker
 
-We have a [Dockerfile](Dockerfile) that will be descently fast for startup. It is tuned specifically for `device=insane`. If you have extremely large batches of data you'd like to convert all at once then consider using the sister project [transcribe-everything](https://github.com/zackees/transcribe-everything) which operates on entire remote paths hierarchies.
+We have a GPU accelerated [Dockerfile](Dockerfile). The default image is intentionally lean: it installs the front end and CUDA runtime, but builds isolated backend environments on first use instead of baking several GB of backend packages into every image. If you want a prebuilt backend image for faster cold starts, use `PREBUILD_BACKENDS`.
+
+```bash
+# Lean default image
+docker build -t transcribe-anything .
+
+# Prebuild normal insanely-fast-whisper backend
+docker build --build-arg PREBUILD_BACKENDS=insane -t transcribe-anything:insane-prebuilt .
+
+# Prebuild FlashAttention backend; this is intentionally opt-in because it is large
+docker build --build-arg PREBUILD_BACKENDS=insane-flash -t transcribe-anything:insane-flash-prebuilt .
+
+# Prebuild both CUDA insane backends
+docker build --build-arg PREBUILD_BACKENDS=both -t transcribe-anything:cuda-prebuilt .
+```
+
+If you have extremely large batches of data you'd like to convert all at once then consider using the sister project [transcribe-everything](https://github.com/zackees/transcribe-everything) which operates on entire remote paths hierarchies.
 
 # GPU Acceleration
 

--- a/tests/test_cuda_version_upgrade.py
+++ b/tests/test_cuda_version_upgrade.py
@@ -328,6 +328,18 @@ class TestDockerfileConsistency(unittest.TestCase):
         self.assertNotIn("2.6.0", text)
         self.assertNotIn("2.2.1", text)
 
+    def test_dockerfile_backend_prebuild_is_opt_in(self):
+        dockerfile = PROJECT_ROOT / "Dockerfile"
+        if not dockerfile.exists():
+            self.skipTest("Dockerfile not found")
+        text = dockerfile.read_text(encoding="utf-8")
+        self.assertIn("ARG PREBUILD_BACKENDS=none", text)
+        self.assertIn('case "$PREBUILD_BACKENDS"', text)
+        self.assertIn("transcribe-anything-init-insane", text)
+        self.assertIn("transcribe-anything-init-insane-flash", text)
+        self.assertIn("rm -rf /root/.cache/pip /root/.cache/uv /tmp/uv-cache", text)
+        self.assertNotIn("RUN transcribe-anything-init-insane\n", text)
+
 
 # ===========================================================================
 # 6. PyTorch wheel index URL is reachable


### PR DESCRIPTION
﻿## Summary
- Makes Docker backend prebuild opt-in with `PREBUILD_BACKENDS` instead of always baking `transcribe-anything-init-insane` into the default image.
- Keeps optional prebuild support for `insane`, `insane-flash`, and both backends.
- Uses `pip --no-cache-dir` and removes pip/uv temporary caches when prebuilds are requested.
- Documents lean vs prebuilt Docker build commands and adds a static regression test.

## Validation
- `PYTHONPATH=src python -m pytest tests/test_cuda_version_upgrade.py::TestDockerfileConsistency -q` -> 3 passed.
- `docker build --pull=false -t transcribe-anything:docker-trim-test .` -> passed.
- `docker run --rm transcribe-anything:docker-trim-test --only-check-shared-libs` -> passed.
- Docker Desktop local image display: `transcribe-anything:docker-trim-test` is 12.7GB, down from the earlier 39.9GB flash-prebuilt validation image.
- `docker history` shows the default `PREBUILD_BACKENDS=none` layer is only 12.3kB; no backend env is baked into the default image.
