### PR TITLE
Fix Docker insane backend duplication

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -19,6 +19,8 @@ WhisperX is an additional backend exposed as `--device whisperx`; it does not re
 
 The flash dependency is intentionally pinned by direct wheel URL plus sha256 in `src/transcribe_anything/flash_attention_wheels.py`. Do not replace it with an unpinned PyPI `flash-attn` source dependency; unsupported tuples should fail early or get a new checked manifest entry after GPU validation.
 
+Docker sets `TRANSCRIBE_ANYTHING_SHARED_INSANE_BACKEND=flash` so `--device insane` and `--device insane-flash` reuse the same flash-capable backend env. This avoids baking two full torch/CUDA dependency trees into the image. Do not enable that variable for normal local installs unless you intentionally want `--device insane` to carry the FlashAttention dependency too.
+
 If you end up down this rabbit hole implementing a feature and want to test a backend, it's actually easy.
 
 Install the program and then see where a `.venv` is created for the backend you are

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,41 +2,47 @@
 # Prerequisites on HOST:
 #   - nvidia-container-toolkit: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html
 #   - Run with: docker run --gpus all transcribe-anything <args>
-FROM pytorch/pytorch:2.7.0-cuda12.8-cudnn9-runtime
+FROM nvidia/cuda:12.8.0-base-ubuntu22.04
 
 # Prevent Python from writing bytecode and enable unbuffered output
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
+# In Docker, both --device insane and --device insane-flash use one prebuilt
+# FlashAttention-capable backend env to avoid duplicating the full torch stack.
+ENV TRANSCRIBE_ANYTHING_SHARED_INSANE_BACKEND=flash
 
 WORKDIR /app
 
 # Install system dependencies
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends build-essential curl dos2unix && \
+    apt-get install -y --no-install-recommends build-essential ca-certificates curl dos2unix python3 python3-pip python3-venv && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Copy source code and prepare entrypoint
-COPY . .
-RUN chmod +x entrypoint.sh && dos2unix entrypoint.sh
+# Copy only the files needed to install and prebuild backend environments.
+COPY pyproject.toml README.md ./
+COPY src ./src
+COPY check_linux_shared_libraries.py ./
 
 # Install transcribe-anything in editable mode
-RUN pip install --no-cache-dir -e .
+RUN python3 -m pip install --no-cache-dir --upgrade pip setuptools wheel && \
+    python3 -m pip install --no-cache-dir -e .
 
-# Keep the default image lean. Backend environments are built on first use unless
-# PREBUILD_BACKENDS is set to one of: insane, insane-flash, both, all.
+# Prebuild both CUDA insane backends by default using one shared flash-capable
+# env. Use PREBUILD_BACKENDS=none for the smallest image, or one of:
+# insane, insane-flash, both, all.
 # NOTE: GPU is not available during build, so runtime CUDA checks are skipped.
-ARG PREBUILD_BACKENDS=none
+ARG PREBUILD_BACKENDS=both
 RUN set -eux; \
-    prebuild_insane() { UV_CACHE_DIR=/tmp/uv-cache transcribe-anything-init-insane; }; \
-    prebuild_insane_flash() { UV_CACHE_DIR=/tmp/uv-cache transcribe-anything-init-insane-flash; }; \
+    prebuild_shared_insane() { UV_CACHE_DIR=/tmp/uv-cache transcribe-anything-init-insane-flash; }; \
     case "$PREBUILD_BACKENDS" in \
         none|"") ;; \
-        insane) prebuild_insane ;; \
-        insane-flash) prebuild_insane_flash ;; \
-        insane,insane-flash|insane-flash,insane|both|all) prebuild_insane; prebuild_insane_flash ;; \
+        insane|insane-flash|insane,insane-flash|insane-flash,insane|both|all) prebuild_shared_insane ;; \
         *) echo "Unsupported PREBUILD_BACKENDS=$PREBUILD_BACKENDS"; exit 1 ;; \
     esac; \
     rm -rf /root/.cache/pip /root/.cache/uv /tmp/uv-cache /tmp/*
+
+COPY entrypoint.sh ./
+RUN chmod +x entrypoint.sh && dos2unix entrypoint.sh
 
 ENTRYPOINT ["/app/entrypoint.sh"]
 CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -218,20 +218,14 @@ pip install transcribe-anything
 
 # Docker
 
-We have a GPU accelerated [Dockerfile](Dockerfile). The default image is intentionally lean: it installs the front end and CUDA runtime, but builds isolated backend environments on first use instead of baking several GB of backend packages into every image. If you want a prebuilt backend image for faster cold starts, use `PREBUILD_BACKENDS`.
+We have a GPU accelerated [Dockerfile](Dockerfile). The default image prebuilds both CUDA insane backends, but avoids duplicating their full dependency stacks: `--device insane` and `--device insane-flash` share one FlashAttention-capable backend environment inside Docker. If you want the smallest possible image and can tolerate first-run backend setup, use `PREBUILD_BACKENDS=none`.
 
 ```bash
-# Lean default image
+# Prebuilt Docker image for --device insane and --device insane-flash
 docker build -t transcribe-anything .
 
-# Prebuild normal insanely-fast-whisper backend
-docker build --build-arg PREBUILD_BACKENDS=insane -t transcribe-anything:insane-prebuilt .
-
-# Prebuild FlashAttention backend; this is intentionally opt-in because it is large
-docker build --build-arg PREBUILD_BACKENDS=insane-flash -t transcribe-anything:insane-flash-prebuilt .
-
-# Prebuild both CUDA insane backends
-docker build --build-arg PREBUILD_BACKENDS=both -t transcribe-anything:cuda-prebuilt .
+# Lean image; backend envs are built on first use
+docker build --build-arg PREBUILD_BACKENDS=none -t transcribe-anything:lean .
 ```
 
 If you have extremely large batches of data you'd like to convert all at once then consider using the sister project [transcribe-everything](https://github.com/zackees/transcribe-everything) which operates on entire remote paths hierarchies.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,20 +3,27 @@
 # GPU-accelerated transcribe-anything launcher
 # Configures CUDA library paths and validates shared libraries
 
-# Configure CUDA library paths for conda-installed NVIDIA packages
-export LD_LIBRARY_PATH=/opt/conda/lib/python3.11/site-packages/nvidia/cuda_runtime/lib:${LD_LIBRARY_PATH}
-export LD_LIBRARY_PATH=/opt/conda/lib/python3.11/site-packages/nvidia/cuda_runtime/lib64:${LD_LIBRARY_PATH}
-export LD_LIBRARY_PATH=/opt/conda/lib/python3.11/site-packages/nvidia/cudnn/lib:${LD_LIBRARY_PATH}
-export LD_LIBRARY_PATH=/opt/conda/lib/python3.11/site-packages/cusparselt/lib/:${LD_LIBRARY_PATH}
-export LD_LIBRARY_PATH=/opt/conda/lib/python3.11/site-packages/nvidia/cuda_cupti/lib/:${LD_LIBRARY_PATH}
-export LD_LIBRARY_PATH=/opt/conda/lib/python3.11/site-packages/nvidia/cusparse/lib/:${LD_LIBRARY_PATH}
-export LD_LIBRARY_PATH=/opt/conda/lib/python3.11/site-packages/nvidia/cufft/lib/:${LD_LIBRARY_PATH}
-export LD_LIBRARY_PATH=/opt/conda/lib/python3.11/site-packages/nvidia/curand/lib/:${LD_LIBRARY_PATH}
-export LD_LIBRARY_PATH=/opt/conda/lib/python3.11/site-packages/nvidia/cublas/lib/:${LD_LIBRARY_PATH}
-export LD_LIBRARY_PATH=/opt/conda/lib/python3.11/site-packages/nvidia/nccl/lib/:${LD_LIBRARY_PATH}
+# Configure CUDA library paths for the NVIDIA base image and prebuilt backend
+# environments. The torch CUDA wheels install most runtime libraries under the
+# backend venv's site-packages/nvidia/*/lib directories.
+prepend_ld_path() {
+    if [ -d "$1" ]; then
+        export LD_LIBRARY_PATH="$1:${LD_LIBRARY_PATH}"
+    fi
+}
 
-# Validate CUDA shared libraries (only if GPU device is present)
-if [ -e /dev/nvidia0 ]; then
+prepend_ld_path /usr/local/cuda/lib64
+for site_packages in /app/src/transcribe_anything/venv/*/.venv/lib/python*/site-packages; do
+    if [ -d "$site_packages" ]; then
+        prepend_ld_path "$site_packages/torch/lib"
+        for lib_dir in "$site_packages"/nvidia/*/lib "$site_packages"/nvidia/*/lib64 "$site_packages"/cusparselt/lib; do
+            prepend_ld_path "$lib_dir"
+        done
+    fi
+done
+
+# Validate CUDA shared libraries (only if GPU access is present)
+if command -v nvidia-smi >/dev/null 2>&1 && nvidia-smi -L >/dev/null 2>&1; then
     if python3 check_linux_shared_libraries.py; then
         echo "OK: CUDA shared libraries validated"
     else
@@ -24,7 +31,7 @@ if [ -e /dev/nvidia0 ]; then
         echo "Ensure container was started with: docker run --gpus all ..."
     fi
 else
-    echo "NOTE: No GPU device detected (/dev/nvidia0). Running in CPU-only mode."
+    echo "NOTE: No NVIDIA GPU detected by nvidia-smi. Running in CPU-only mode."
 fi
 
 # Exit early if only checking libraries

--- a/src/transcribe_anything/_cmd.py
+++ b/src/transcribe_anything/_cmd.py
@@ -19,7 +19,6 @@ from appdirs import user_cache_dir  # type: ignore
 
 from transcribe_anything.parse_whisper_options import parse_whisper_options
 from transcribe_anything.util import detect_macos_x86_unsupported
-from transcribe_anything.whisper import get_computing_device
 
 HERE = Path(os.path.abspath(os.path.dirname(__file__)))
 WHISPER_OPTIONS = HERE / "WHISPER_OPTIONS.json"
@@ -98,8 +97,7 @@ def get_whisper_options() -> dict:
 def parse_arguments() -> argparse.Namespace:
     """Parse arguments."""
     whisper_options = get_whisper_options()
-    device = get_computing_device()
-    help_str = f'transcribe_anything is using a "{device}" device.' " Any unrecognized args are assumed to be for whisper" " ai and will be passed as is to whisper ai."
+    help_str = "Any unrecognized args are assumed to be for the selected whisper backend and will be passed through."
     parser = argparse.ArgumentParser(description=help_str)
     parser.add_argument(
         "url_or_file",

--- a/src/transcribe_anything/insanley_fast_whisper_reqs.py
+++ b/src/transcribe_anything/insanley_fast_whisper_reqs.py
@@ -2,12 +2,16 @@
 Requirements for the insanely fast whisper.
 """
 
+import os
 import sys
 from pathlib import Path
 
 from iso_env import IsoEnv, IsoEnvArgs, PyProjectToml  # type: ignore
 
-from transcribe_anything.flash_attention_wheels import SUPPORTED_PYTHON_TAG, get_flash_attention_wheel
+from transcribe_anything.flash_attention_wheels import (
+    SUPPORTED_PYTHON_TAG,
+    get_flash_attention_wheel,
+)
 from transcribe_anything.util import has_nvidia_smi
 
 HERE = Path(__file__).parent
@@ -20,6 +24,7 @@ EXTRA_INDEX_URL = f"https://download.pytorch.org/whl/{CUDA_VERSION}"
 PYTHON_VERSION = "==3.11.*"
 INSANE_ENV_NAME = "insanely_fast_whisper"
 INSANE_FLASH_ENV_NAME = "insanely_fast_whisper_flash"
+SHARED_INSANE_BACKEND_ENV_VAR = "TRANSCRIBE_ANYTHING_SHARED_INSANE_BACKEND"
 
 
 def get_current_python_version() -> str:
@@ -116,12 +121,21 @@ def build_pyproject_toml(has_nvidia: bool, flash: bool = False) -> str:
     return "\n".join(content_lines)
 
 
+def _use_shared_flash_backend(has_nvidia: bool, flash: bool) -> bool:
+    """Return True when normal insane should reuse the flash-capable env."""
+    if flash:
+        return True
+    value = os.environ.get(SHARED_INSANE_BACKEND_ENV_VAR, "").strip().lower()
+    return has_nvidia and value in {"1", "true", "yes", "y", "on", "flash", "insane-flash"}
+
+
 def get_environment(has_nvidia: bool | None = None, flash: bool = False) -> IsoEnv:
     """Returns the isolated insane or insane-flash environment."""
-    env_name = INSANE_FLASH_ENV_NAME if flash else INSANE_ENV_NAME
-    venv_dir = HERE / "venv" / env_name
     if has_nvidia is None:
         has_nvidia = has_nvidia_smi()
+    flash = _use_shared_flash_backend(has_nvidia=has_nvidia, flash=flash)
+    env_name = INSANE_FLASH_ENV_NAME if flash else INSANE_ENV_NAME
+    venv_dir = HERE / "venv" / env_name
     content = build_pyproject_toml(has_nvidia=has_nvidia, flash=flash)
     build_info = PyProjectToml(content)
     args = IsoEnvArgs(venv_path=venv_dir, build_info=build_info)

--- a/tests/test_cuda_version_upgrade.py
+++ b/tests/test_cuda_version_upgrade.py
@@ -316,7 +316,7 @@ class TestDockerfileConsistency(unittest.TestCase):
         if not dockerfile.exists():
             self.skipTest("Dockerfile not found")
         text = dockerfile.read_text(encoding="utf-8")
-        self.assertIn("pytorch/pytorch:2.7.0-cuda12.8", text)
+        self.assertIn("nvidia/cuda:12.8.0-base-ubuntu22.04", text)
 
     def test_dockerfile_no_old_base_images(self):
         dockerfile = PROJECT_ROOT / "Dockerfile"
@@ -325,20 +325,29 @@ class TestDockerfileConsistency(unittest.TestCase):
         text = dockerfile.read_text(encoding="utf-8")
         self.assertNotIn("cuda12.6", text)
         self.assertNotIn("cuda12.1", text)
+        self.assertNotIn("pytorch/pytorch", text)
         self.assertNotIn("2.6.0", text)
         self.assertNotIn("2.2.1", text)
 
-    def test_dockerfile_backend_prebuild_is_opt_in(self):
+    def test_dockerfile_uses_shared_prebuilt_insane_backend(self):
         dockerfile = PROJECT_ROOT / "Dockerfile"
         if not dockerfile.exists():
             self.skipTest("Dockerfile not found")
         text = dockerfile.read_text(encoding="utf-8")
-        self.assertIn("ARG PREBUILD_BACKENDS=none", text)
+        self.assertIn("TRANSCRIBE_ANYTHING_SHARED_INSANE_BACKEND=flash", text)
+        self.assertIn("ARG PREBUILD_BACKENDS=both", text)
         self.assertIn('case "$PREBUILD_BACKENDS"', text)
-        self.assertIn("transcribe-anything-init-insane", text)
         self.assertIn("transcribe-anything-init-insane-flash", text)
+        self.assertNotIn("transcribe-anything-init-insane;", text)
         self.assertIn("rm -rf /root/.cache/pip /root/.cache/uv /tmp/uv-cache", text)
-        self.assertNotIn("RUN transcribe-anything-init-insane\n", text)
+
+    def test_entrypoint_uses_nvidia_smi_for_gpu_detection(self):
+        entrypoint = PROJECT_ROOT / "entrypoint.sh"
+        if not entrypoint.exists():
+            self.skipTest("entrypoint.sh not found")
+        text = entrypoint.read_text(encoding="utf-8")
+        self.assertIn("nvidia-smi -L", text)
+        self.assertNotIn("[ -e /dev/nvidia0 ]", text)
 
 
 # ===========================================================================

--- a/tests/test_insane_flash_cmd_arg.py
+++ b/tests/test_insane_flash_cmd_arg.py
@@ -51,13 +51,26 @@ def test_cli_parser_accepts_insane_flash_and_preserves_backend_args() -> None:
     with (
         mock.patch.object(sys, "argv", argv),
         mock.patch.object(_cmd, "get_whisper_options", return_value=WHISPER_OPTIONS),
-        mock.patch.object(_cmd, "get_computing_device", return_value="cpu"),
     ):
         args = _cmd.parse_arguments()
 
     assert args.device == "insane-flash"
     assert args.timestamp == "word"
     assert args.unknown == ["--batch-size", "2"]
+
+
+def test_cli_parser_does_not_probe_standard_whisper_env_for_explicit_device() -> None:
+    from transcribe_anything import _cmd
+
+    argv = ["transcribe-anything", "sample.wav", "--device", "insane", "--model", "tiny"]
+    with (
+        mock.patch.object(sys, "argv", argv),
+        mock.patch.object(_cmd, "get_whisper_options", return_value=WHISPER_OPTIONS),
+        mock.patch("transcribe_anything.whisper.get_computing_device", side_effect=AssertionError("should not probe standard whisper env")),
+    ):
+        args = _cmd.parse_arguments()
+
+    assert args.device == "insane"
 
 
 def test_cli_main_routes_insane_flash_to_api_and_forwards_insane_args(tmp_path: Path) -> None:
@@ -86,7 +99,6 @@ def test_cli_main_routes_insane_flash_to_api_and_forwards_insane_args(tmp_path: 
     with (
         mock.patch.object(sys, "argv", argv),
         mock.patch.object(_cmd, "get_whisper_options", return_value=WHISPER_OPTIONS),
-        mock.patch.object(_cmd, "get_computing_device", return_value="cpu"),
         mock.patch.object(_cmd, "user_cache_dir", return_value=str(tmp_path)),
         mock.patch.dict("os.environ", {}, clear=True),
         mock.patch.object(api, "transcribe", fake_transcribe),

--- a/tests/test_insane_flash_reqs.py
+++ b/tests/test_insane_flash_reqs.py
@@ -115,3 +115,69 @@ def test_get_environment_uses_dedicated_flash_venv() -> None:
     assert venv_path.name == "insanely_fast_whisper_flash"
     assert "venv" in venv_path.parts
     assert "flash-attn @" in captured["content"]
+
+
+def test_shared_insane_backend_env_var_reuses_flash_venv(monkeypatch: pytest.MonkeyPatch) -> None:
+    import transcribe_anything.insanley_fast_whisper_reqs as reqs
+    from transcribe_anything import flash_attention_wheels
+
+    captured: dict[str, Any] = {}
+
+    class FakePyProjectToml:
+        def __init__(self, content: str) -> None:
+            captured["content"] = content
+
+    class FakeIsoEnvArgs:
+        def __init__(self, venv_path: Path, build_info: Any) -> None:
+            captured["venv_path"] = venv_path
+            self.venv_path = venv_path
+            self.build_info = build_info
+
+    class FakeIsoEnv:
+        def __init__(self, args: Any) -> None:
+            self.args = args
+
+    monkeypatch.setenv("TRANSCRIBE_ANYTHING_SHARED_INSANE_BACKEND", "flash")
+    with (
+        mock.patch.object(reqs, "PyProjectToml", FakePyProjectToml),
+        mock.patch.object(reqs, "IsoEnvArgs", FakeIsoEnvArgs),
+        mock.patch.object(reqs, "IsoEnv", FakeIsoEnv),
+        mock.patch.object(flash_attention_wheels.platform, "system", return_value="Windows"),
+        mock.patch.object(flash_attention_wheels.platform, "machine", return_value="AMD64"),
+        mock.patch.object(flash_attention_wheels, "current_python_tag", return_value="cp311"),
+    ):
+        reqs.get_environment(has_nvidia=True, flash=False)
+
+    assert Path(captured["venv_path"]).name == "insanely_fast_whisper_flash"
+    assert "flash-attn @" in captured["content"]
+
+
+def test_shared_insane_backend_env_var_does_not_force_flash_without_nvidia(monkeypatch: pytest.MonkeyPatch) -> None:
+    import transcribe_anything.insanley_fast_whisper_reqs as reqs
+
+    captured: dict[str, Any] = {}
+
+    class FakePyProjectToml:
+        def __init__(self, content: str) -> None:
+            captured["content"] = content
+
+    class FakeIsoEnvArgs:
+        def __init__(self, venv_path: Path, build_info: Any) -> None:
+            captured["venv_path"] = venv_path
+            self.venv_path = venv_path
+            self.build_info = build_info
+
+    class FakeIsoEnv:
+        def __init__(self, args: Any) -> None:
+            self.args = args
+
+    monkeypatch.setenv("TRANSCRIBE_ANYTHING_SHARED_INSANE_BACKEND", "flash")
+    with (
+        mock.patch.object(reqs, "PyProjectToml", FakePyProjectToml),
+        mock.patch.object(reqs, "IsoEnvArgs", FakeIsoEnvArgs),
+        mock.patch.object(reqs, "IsoEnv", FakeIsoEnv),
+    ):
+        reqs.get_environment(has_nvidia=False, flash=False)
+
+    assert Path(captured["venv_path"]).name == "insanely_fast_whisper"
+    assert "flash-attn" not in captured["content"]

--- a/tests/test_whisperx_cmd_arg.py
+++ b/tests/test_whisperx_cmd_arg.py
@@ -68,8 +68,7 @@ def test_cli_parser_accepts_whisperx_options_and_preserves_unknown_backend_args(
     ]
     with mock.patch.object(sys, "argv", argv):
         with mock.patch.object(_cmd, "get_whisper_options", return_value=WHISPER_OPTIONS):
-            with mock.patch.object(_cmd, "get_computing_device", return_value="cpu"):
-                args = _cmd.parse_arguments()
+            args = _cmd.parse_arguments()
 
     assert args.device == "whisperx"
     assert args.model == "tiny"
@@ -107,9 +106,8 @@ def test_cli_main_routes_whisperx_to_api_and_forwards_backend_args() -> None:
     ]
     with mock.patch.object(sys, "argv", argv):
         with mock.patch.object(_cmd, "get_whisper_options", return_value=WHISPER_OPTIONS):
-            with mock.patch.object(_cmd, "get_computing_device", return_value="cpu"):
-                with mock.patch.object(api, "transcribe", fake_transcribe):
-                    assert _cmd.main() == 0
+            with mock.patch.object(api, "transcribe", fake_transcribe):
+                assert _cmd.main() == 0
 
     assert len(calls) == 1
     assert calls[0]["device"] == "whisperx"


### PR DESCRIPTION
## Summary
- keep the default Docker image prebuilding both `--device insane` and `--device insane-flash`, but route both through one shared FlashAttention-capable backend env in Docker
- switch the image base from `pytorch/pytorch:2.7.0-cuda12.8-cudnn9-runtime` to `nvidia/cuda:12.8.0-base-ubuntu22.04` so the PyTorch/CUDA stack is not duplicated between the base image and backend venv
- avoid eager standard Whisper env creation during CLI argument parsing, and update the entrypoint to discover CUDA libraries from prebuilt backend venvs

## Size notes
- default prebuilt image: `docker images` reports `15GB`; `docker image inspect` reports `4,914,361,507` bytes
- lean image with `--build-arg PREBUILD_BACKENDS=none`: `docker images` reports `1.08GB`; `docker image inspect` reports `268,565,788` bytes
- Docker history shows one remaining large backend layer (`9.23GB`), which is the shared FlashAttention-capable insane backend env rather than two separate backend stacks plus a PyTorch base stack

## Validation
- `./lint` completed successfully; it also ran ruff locally before unrelated formatter churn was removed
- `. ./activate && python -m pytest tests/test_whisperx_reqs.py tests/test_whisperx_cmd_arg.py tests/test_whisperx_json_to_srt_txt.py tests/test_insane_flash_reqs.py tests/test_insane_flash_cmd_arg.py tests/test_cuda_version_upgrade.py::TestDockerfileConsistency -q` -> `35 passed`
- `git diff --check`
- `docker build --pull=false -t transcribe-anything:shared-insane-backends .`
- `docker build --pull=false --build-arg PREBUILD_BACKENDS=none -t transcribe-anything:shared-lean-test .`
- `docker run --rm --gpus all transcribe-anything:shared-insane-backends --only-check-shared-libs`
- sample Docker transcriptions for `--device insane` and `--device insane-flash` on `tests/localfile/video.wav` both produced outputs; the generated `out.srt` files were identical

## Note
- A full `./test` run was attempted after `./install`, but it exceeded the 15-minute local timeout and was stopped. The focused changed tests and Docker runtime validation passed.