### PR TITLE
docs: link community RunPod Serverless deployment (closes #94)

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,10 @@ Mac:
 
 - Use `--device mlx`
 
+# Cloud / Serverless (no local GPU)
+
+Don't have a local NVIDIA GPU? Community member [@victorkjung](https://github.com/victorkjung) maintains a turnkey [RunPod Serverless deployment](https://github.com/victorkjung/transcribe-anything/tree/runpod-integration/runpod) of `transcribe-anything` that runs `--device insane` on per-second-billed GPU minutes that scale to zero. It ships a Dockerfile, RunPod handler, reference Python client, and an optional self-hosted webapp. This is a third-party fork, not an official deployment — issues and support live in that repo.
+
 # Advanced Options and Backend-Specific Arguments
 
 ## Quick Reference


### PR DESCRIPTION
## Summary

- Adds a new top-level section `# Cloud / Serverless (no local GPU)` between `# GPU Acceleration` and `# Advanced Options and Backend-Specific Arguments`.
- Links to @victorkjung's RunPod Serverless fork as a turnkey deployment for users without a local NVIDIA GPU.
- Includes a \"third-party fork, not an official deployment\" disclaimer so support routes to the fork's issue tracker, not here.

## Why this slot

The reader of `# GPU Acceleration` was just told to use `--device insane` on Windows/Linux. The natural next question for a Mac-without-MLX or Linux-without-GPU user is \"what if I don't have a local GPU?\" — answering it inline avoids burying the answer.

## Why endorse one fork

The README already credits individual community contributors by name (e.g., MLX backend credit to @aj47 line 34) and links sister projects in Notes. Singling out a working fork is consistent with the maintainer's posture. If a Modal/Replicate equivalent surfaces later, the section retitles to a bulleted list.

## Test plan

- [x] README renders cleanly (markdown linter green; H1 hierarchy preserved)
- [ ] Link to victorkjung/transcribe-anything resolves (verified during writing)

Closes #94.