### PR TITLE
refactor(audio): drop shell=True from _convert_to_wav (closes #96)

### DIFF
--- a/src/transcribe_anything/audio.py
+++ b/src/transcribe_anything/audio.py
@@ -20,27 +20,32 @@ def _convert_to_wav(inpath: str, outpath: str, speech_normalization: bool = Fals
     tmpwav.close()
     tmpwavepath = tmpwav.name
 
-    cmd_list = ["static_ffmpeg", "-y", "-i", str(inpath)]
+    static_ffmpeg_path = shutil.which("static_ffmpeg")
+    if static_ffmpeg_path is None:
+        raise FileNotFoundError("No path for static_ffmpeg")
+    cmd_list = [static_ffmpeg_path, "-y", "-i", str(inpath)]
     if speech_normalization:
         cmd_list += [
             "-filter:a",
             "speechnorm=e=12.5:r=0.00001:l=1",
         ]
     cmd_list += ["-acodec", "pcm_s16le", "-ar", "16000", "-ac", "1", str(tmpwavepath)]
-    cmd = subprocess.list2cmdline(cmd_list)
-    print(f"Running:\n  {cmd}")
+    cmd_str = subprocess.list2cmdline(cmd_list)
+    print(f"Running:\n  {cmd_str}")
     try:
         subprocess.run(
-            cmd,
-            shell=True,
-            check=False,
+            cmd_list,
+            shell=False,
+            check=True,
             capture_output=True,
             timeout=PROCESS_TIMEOUT,
         )
     except subprocess.CalledProcessError as exc:
-        print(f"Failed to run {cmd} with error {exc}")
-        print(f"stdout: {exc.stdout}")
-        print(f"stderr: {exc.stderr}")
+        print(f"Failed to run {cmd_str} with error {exc}")
+        stdout = exc.stdout.decode(errors="replace") if isinstance(exc.stdout, bytes) else exc.stdout
+        stderr = exc.stderr.decode(errors="replace") if isinstance(exc.stderr, bytes) else exc.stderr
+        print(f"stdout: {stdout}")
+        print(f"stderr: {stderr}")
         raise
     os.remove(outpath)
     # os.rename(tmpwavepath, outpath)


### PR DESCRIPTION
## Summary

- `_convert_to_wav` now invokes ffmpeg as an argv-list with `shell=False` and `check=True`, matching the convention already used in `fetch_audio`'s local-file path.
- Resolves `static_ffmpeg` via `shutil.which` so the call works under `shell=False` without depending on PATH-resolver `.exe` extension behavior on Windows.
- Decodes `stdout`/`stderr` bytes defensively in the error path.

## Why

Two real issues with the old code:

1. **`shell=True` is a shell-injection surface.** The input filename flows through `cmd_list` into a shell-rendered string. Filenames containing `;`, `\$(...)`, backticks, or `|` would be re-interpreted by the shell. Today's call sites probably don't expose that, but `shell=True` keeps the door open.
2. **`check=False` swallows failures.** ffmpeg exiting non-zero (bad input, codec missing) silently produced an empty wav, then whisper failed in a confusing place far from the real error.

## Test plan

- [x] Existing test suite runs (no audio-specific unit test exists; covered by integration tests `test_transcribe_anything.py` / `test_api.py`).
- [x] Smoke check: `_convert_to_wav` reaches the new argv-list path; no behavior change for happy-path inputs.
- [x] Diff is minimal — 14 inserts / 9 deletes, all inside `_convert_to_wav`.

Closes #96.