### PR TITLE
refactor(util): move backend venvs + static_ffmpeg cache out of source tree (closes #95, #97)

### DIFF
--- a/src/transcribe_anything/api.py
+++ b/src/transcribe_anything/api.py
@@ -20,12 +20,13 @@ from pathlib import Path
 from typing import Any, Optional
 
 import static_ffmpeg  # type: ignore
+import static_ffmpeg.run as static_ffmpeg_run  # type: ignore
 from appdirs import user_config_dir  # type: ignore
 
 from transcribe_anything.audio import fetch_audio
 from transcribe_anything.insanely_fast_whisper import run_insanely_fast_whisper
 from transcribe_anything.logger import log_error
-from transcribe_anything.util import chop_double_extension, sanitize_filename
+from transcribe_anything.util import chop_double_extension, get_static_ffmpeg_runtime_dir, sanitize_filename
 from transcribe_anything.whisper import get_computing_device, run_whisper
 from transcribe_anything.whisper_mac import run_whisper_mac_mlx
 
@@ -46,6 +47,19 @@ os.environ["PYTHONIOENCODING"] = "utf-8"
 CACHE_FILE = os.path.join(user_config_dir("transcript-anything", "cache", roaming=True))
 
 PERMS = stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH | stat.S_IWOTH | stat.S_IWUSR | stat.S_IWGRP
+
+
+def _add_static_ffmpeg_paths() -> None:
+    """Add ffmpeg/ffprobe to PATH, downloading into a writable runtime dir.
+
+    static_ffmpeg's default download_dir lives alongside its wheel inside
+    site-packages, which fails under read-only installs (Nix store, OS
+    packages, baked containers). Point both download_dir and LOCK_FILE at
+    the user cache so the download lands somewhere writable.
+    """
+    ffmpeg_cache = get_static_ffmpeg_runtime_dir()
+    static_ffmpeg_run.LOCK_FILE = str(ffmpeg_cache / "lock.file")
+    static_ffmpeg.add_paths(download_dir=str(ffmpeg_cache / static_ffmpeg_run.get_platform_key()))
 
 
 class Device(Enum):
@@ -204,7 +218,7 @@ def transcribe(
         Path to the output directory containing transcription files
     """
     # add the paths for any dependent tools that may rely on ffmpeg
-    static_ffmpeg.add_paths()
+    _add_static_ffmpeg_paths()
     if not os.path.isfile(url_or_file) and embed:
         raise NotImplementedError("Embedding is only supported for local files. " + "Please download the file first.")
     # cache = DiskLRUCache(CACHE_FILE, 16)

--- a/src/transcribe_anything/insanely_fast_whisper.py
+++ b/src/transcribe_anything/insanely_fast_whisper.py
@@ -19,12 +19,13 @@ from pathlib import Path
 from typing import Any, Optional
 
 import static_ffmpeg  # type: ignore
+import static_ffmpeg.run as static_ffmpeg_run  # type: ignore
 import webvtt  # type: ignore
 
 from transcribe_anything.cuda_available import CudaInfo
 from transcribe_anything.generate_speaker_json import generate_speaker_json
 from transcribe_anything.insanley_fast_whisper_reqs import get_environment
-from transcribe_anything.util import print_cuda_diagnostics
+from transcribe_anything.util import get_static_ffmpeg_runtime_dir, print_cuda_diagnostics
 
 HERE = Path(__file__).parent
 CUDA_INFO: Optional[CudaInfo] = None
@@ -390,7 +391,9 @@ def run_insanely_fast_whisper(
 ) -> None:
     """Runs insanely fast whisper."""
     # ffmpeg paths have to be installed or else the backend tool will fail.
-    static_ffmpeg.add_paths()
+    ffmpeg_cache = get_static_ffmpeg_runtime_dir()
+    static_ffmpeg_run.LOCK_FILE = str(ffmpeg_cache / "lock.file")
+    static_ffmpeg.add_paths(download_dir=str(ffmpeg_cache / static_ffmpeg_run.get_platform_key()))
     iso_env = get_environment(flash=flash)
     backend_args = _prepare_insane_args(other_args, force_flash=flash)
     if flash:

--- a/src/transcribe_anything/insanley_fast_whisper_reqs.py
+++ b/src/transcribe_anything/insanley_fast_whisper_reqs.py
@@ -12,7 +12,7 @@ from transcribe_anything.flash_attention_wheels import (
     SUPPORTED_PYTHON_TAG,
     get_flash_attention_wheel,
 )
-from transcribe_anything.util import has_nvidia_smi
+from transcribe_anything.util import get_runtime_venv_dir, has_nvidia_smi
 
 HERE = Path(__file__).parent
 
@@ -135,7 +135,7 @@ def get_environment(has_nvidia: bool | None = None, flash: bool = False) -> IsoE
         has_nvidia = has_nvidia_smi()
     flash = _use_shared_flash_backend(has_nvidia=has_nvidia, flash=flash)
     env_name = INSANE_FLASH_ENV_NAME if flash else INSANE_ENV_NAME
-    venv_dir = HERE / "venv" / env_name
+    venv_dir = get_runtime_venv_dir(env_name)
     content = build_pyproject_toml(has_nvidia=has_nvidia, flash=flash)
     build_info = PyProjectToml(content)
     args = IsoEnvArgs(venv_path=venv_dir, build_info=build_info)

--- a/src/transcribe_anything/parse_whisper_options.py
+++ b/src/transcribe_anything/parse_whisper_options.py
@@ -9,12 +9,12 @@ from pathlib import Path
 from typing import Any
 
 from transcribe_anything import logger
-from transcribe_anything.whisper import HERE as _WHISPER_HERE
+from transcribe_anything.util import get_runtime_venv_dir
 from transcribe_anything.whisper import get_environment
 
 PATTERN = r"\s+\[--(.*?)\]"
 
-_WHISPER_VENV_DIR: Path = _WHISPER_HERE / "venv" / "whisper"
+_WHISPER_VENV_DIR: Path = get_runtime_venv_dir("whisper")
 
 
 def _whisper_venv_exists() -> bool:

--- a/src/transcribe_anything/srt_translation.py
+++ b/src/transcribe_anything/srt_translation.py
@@ -17,7 +17,7 @@ WRAP_SRT_PY = HERE / "srt_wrap.py"
 
 def get_environment() -> IsoEnv:
     """Returns the environment."""
-    venv_path = HERE / "venv" / "srttranslator"
+    venv_path = get_runtime_venv_dir("srttranslator")
     reqs_text = "\n".join(["srtranslator==0.3.9", "requests==2.28.1", "urllib3==1.26.13"])
     reqs = Requirements(
         reqs_text,

--- a/src/transcribe_anything/util.py
+++ b/src/transcribe_anything/util.py
@@ -15,11 +15,45 @@ from pathlib import Path
 from typing import Callable, Optional
 from urllib.parse import unquote
 
+from appdirs import user_cache_dir  # type: ignore
+
 PROCESS_TIMEOUT = 4 * 60 * 60
 
 # Cache file for NVIDIA detection to ensure consistency across runs
 _NVIDIA_CACHE_FILE = Path.home() / ".transcribe_anything_nvidia_cache.json"
 _NVIDIA_DETECTION_CACHE = None
+
+
+def get_runtime_dir() -> Path:
+    """Return the writable cache directory used for backend venvs and static_ffmpeg.
+
+    Backends used to keep their iso-env venvs alongside the installed
+    Python source (``<package>/venv/<backend>``), which breaks under any
+    install where the package landed in a read-only location: Nix store,
+    OS-package install (e.g. /usr/lib), multi-user shared install,
+    pip --target with a read-only mount, baked-into-container installs.
+
+    Override the location with the ``TRANSCRIBE_ANYTHING_CACHE_DIR`` env
+    var; otherwise fall back to the standard per-user cache directory.
+    """
+    override = os.environ.get("TRANSCRIBE_ANYTHING_CACHE_DIR")
+    runtime_dir = Path(override) if override else Path(user_cache_dir("transcribe-anything"))
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    return runtime_dir
+
+
+def get_runtime_venv_dir(name: str) -> Path:
+    """Return a writable per-backend virtualenv directory under :func:`get_runtime_dir`."""
+    venv_dir = get_runtime_dir() / "venv" / name
+    venv_dir.mkdir(parents=True, exist_ok=True)
+    return venv_dir
+
+
+def get_static_ffmpeg_runtime_dir() -> Path:
+    """Return the writable directory used for the static_ffmpeg download + lock file."""
+    ffmpeg_dir = get_runtime_dir() / "static_ffmpeg"
+    ffmpeg_dir.mkdir(parents=True, exist_ok=True)
+    return ffmpeg_dir
 
 
 def is_mac_arm() -> bool:

--- a/src/transcribe_anything/whisper.py
+++ b/src/transcribe_anything/whisper.py
@@ -10,7 +10,7 @@ from typing import Optional
 
 from iso_env import IsoEnv, IsoEnvArgs, PyProjectToml  # type: ignore
 
-from transcribe_anything.util import has_nvidia_smi
+from transcribe_anything.util import get_runtime_venv_dir, has_nvidia_smi
 
 # from isolated_environment import isolated_environment  # type: ignore
 
@@ -28,7 +28,7 @@ IS_MAC = sys.platform == "darwin"
 
 def get_environment() -> IsoEnv:
     """Returns the environment."""
-    venv_dir = HERE / "venv" / "whisper"
+    venv_dir = get_runtime_venv_dir("whisper")
     needs_extra_index = not IS_MAC and has_nvidia_smi()
     content_lines: list[str] = []
 

--- a/src/transcribe_anything/whisper_mac.py
+++ b/src/transcribe_anything/whisper_mac.py
@@ -10,6 +10,8 @@ from typing import Any, Dict
 import webvtt  # type: ignore
 from iso_env import IsoEnv, IsoEnvArgs, PyProjectToml  # type: ignore
 
+from transcribe_anything.util import get_runtime_venv_dir
+
 HERE = Path(__file__).parent
 
 
@@ -52,7 +54,7 @@ def _make_pyproject_toml_content() -> str:
 
 def get_environment() -> IsoEnv:
     """Returns the environment for lightning-whisper-mlx."""
-    venv_dir = HERE / "venv" / "whisper_mlx"
+    venv_dir = get_runtime_venv_dir("whisper_mlx")
     content = _make_pyproject_toml_content()
 
     # Debug: Log the pyproject.toml content hash to track changes

--- a/src/transcribe_anything/whisperx.py
+++ b/src/transcribe_anything/whisperx.py
@@ -14,11 +14,12 @@ from pathlib import Path
 from typing import Any
 
 import static_ffmpeg  # type: ignore
+import static_ffmpeg.run as static_ffmpeg_run  # type: ignore
 import webvtt  # type: ignore
 
 from transcribe_anything.generate_speaker_json import Chunk
 from transcribe_anything.generate_speaker_json import reduce as reduce_speaker_chunks
-from transcribe_anything.util import has_nvidia_smi
+from transcribe_anything.util import get_static_ffmpeg_runtime_dir, has_nvidia_smi
 from transcribe_anything.whisperx_reqs import get_environment
 
 HERE = Path(__file__).parent
@@ -434,7 +435,9 @@ def run_whisperx(  # pylint: disable=too-many-arguments
     other_args: list[str] | None = None,
 ) -> None:
     """Run WhisperX through its isolated environment."""
-    static_ffmpeg.add_paths()
+    ffmpeg_cache = get_static_ffmpeg_runtime_dir()
+    static_ffmpeg_run.LOCK_FILE = str(ffmpeg_cache / "lock.file")
+    static_ffmpeg.add_paths(download_dir=str(ffmpeg_cache / static_ffmpeg_run.get_platform_key()))
     iso_env = get_environment()
     passthrough_args, arg_hf_token = _parse_other_args(other_args)
     hf_token = hugging_face_token or arg_hf_token

--- a/src/transcribe_anything/whisperx_reqs.py
+++ b/src/transcribe_anything/whisperx_reqs.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from iso_env import IsoEnv, IsoEnvArgs, PyProjectToml  # type: ignore
 
-from transcribe_anything.util import has_nvidia_smi
+from transcribe_anything.util import get_runtime_venv_dir, has_nvidia_smi
 
 HERE = Path(__file__).parent
 
@@ -80,7 +80,7 @@ def build_pyproject_toml(has_nvidia: bool) -> str:
 
 def get_environment(has_nvidia: bool | None = None) -> IsoEnv:
     """Returns the isolated WhisperX environment."""
-    venv_dir = HERE / "venv" / "whisperx"
+    venv_dir = get_runtime_venv_dir("whisperx")
     if has_nvidia is None:
         has_nvidia = has_nvidia_smi()
     build_info = PyProjectToml(build_pyproject_toml(has_nvidia))


### PR DESCRIPTION
## Summary

Five backends + `parse_whisper_options` were writing iso-env venvs to `HERE / \"venv\" / <backend>`, and `static_ffmpeg.add_paths()` was downloading the ffmpeg binary into the `static_ffmpeg` wheel directory. Both fail on any install where the package landed in a read-only location: Nix store, OS-package install, multi-user shared install, pip `--target` with a read-only mount, baked-into-container installs.

Three new helpers in `util.py`:

- `get_runtime_dir() -> Path` — `<user_cache_dir>/transcribe-anything`, overridable via `TRANSCRIBE_ANYTHING_CACHE_DIR` env var.
- `get_runtime_venv_dir(name) -> Path` — `<runtime>/venv/<name>`.
- `get_static_ffmpeg_runtime_dir() -> Path` — `<runtime>/static_ffmpeg`.

Cascade:

- **Venvs** (`whisper.py`, `whisper_mac.py`, `whisperx_reqs.py`, `insanley_fast_whisper_reqs.py`, `srt_translation.py`, `parse_whisper_options.py`): `HERE / \"venv\" / X` → `get_runtime_venv_dir(\"X\")`.
- **static_ffmpeg** (`api.py`, `insanely_fast_whisper.py`, `whisperx.py`): `static_ffmpeg.add_paths()` → set `static_ffmpeg_run.LOCK_FILE` + call `add_paths(download_dir=…)` pointing at the writable cache.

Carve-outs from PR #68; reference implementation reviewed against current `main`.

## Behavior change

Existing installs have a cached venv at the old `HERE/venv/<backend>` path. On upgrade, those caches become orphaned and the user silently re-downloads ~10 GB of wheels on first use of each backend. Documented in the commit message; not migrating automatically — added complexity for a one-time event.

## Test plan

- [x] Smoke test: `python -c \"from transcribe_anything.util import get_runtime_dir, get_runtime_venv_dir, get_static_ffmpeg_runtime_dir; ...\"` returns valid paths on Windows.
- [x] Import-sanity: every backend module + util module imports cleanly with the new helpers.
- [ ] CI: full suite on ubuntu/macos/windows.
- [ ] Manual: confirm `--device whisperx` and `--device insane` succeed against a small audio file (covered by integration tests).

Closes #95.
Closes #97.