### PR TITLE
feat(insane): add --align post-pass using WhisperX forced alignment (refs #81)

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,13 +253,13 @@ Don't have a local NVIDIA GPU? Community member [@victorkjung](https://github.co
 | Backend | Device Flag | Key Arguments | Best For |
 |---------|-------------|---------------|----------|
 | **MLX** | `--device mlx` | `--batch_size`, `--verbose`, `--initial_prompt` | Mac Apple Silicon |
-| **Insanely Fast** | `--device insane` | `--batch-size`, `--hf_token`, `--timestamp` | Windows/Linux GPU |
-| **Insane Flash** | `--device insane-flash` | `--batch-size`, `--hf_token`, `--timestamp` | CUDA GPU with verified FlashAttention2 |
+| **Insanely Fast** | `--device insane` | `--batch-size`, `--hf_token`, `--timestamp`, `--align` | Windows/Linux GPU |
+| **Insane Flash** | `--device insane-flash` | `--batch-size`, `--hf_token`, `--timestamp`, `--align` | CUDA GPU with verified FlashAttention2 |
 | **WhisperX** | `--device whisperx` | `--compute_type`, `--diarize`, `--batch_size`, `--align_model` | Alignment, diarization, word timing |
 | **SenseVoice** | `--device sensevoice` | `--diarize`, `--language`, `--hub` | FunASR/SenseVoice; multilingual (zh/en/yue/ja/ko), built-in VAD + emotion |
 | **CPU** | `--device cpu` | Standard whisper args | Universal compatibility |
 
-> **Note:** Each backend has different capabilities. MLX is optimized for Apple Silicon with a focused feature set. Insanely Fast uses a transformer-based architecture with specific options. `insane-flash` is the same backend family with verified FlashAttention2 dependencies. WhisperX is an additive backend for alignment and diarization, not a replacement for `--device insane`. SenseVoice wraps FunASR's `iic/SenseVoiceSmall` model — multilingual (zh/en/yue/ja/ko), non-autoregressive, with built-in VAD; diarization (cam++) is opt-in via `--diarize`. Models download from ModelScope by default; pass `--hub hf` to use HuggingFace instead. CPU backend supports the full range of standard OpenAI Whisper arguments.
+> **Note:** Each backend has different capabilities. MLX is optimized for Apple Silicon with a focused feature set. Insanely Fast uses a transformer-based architecture with specific options. `insane-flash` is the same backend family with verified FlashAttention2 dependencies. Both insane backends accept an opt-in `--align` flag that runs a WhisperX wav2vec2 forced-alignment post-pass on the transcript, replacing the HF pipeline's segment-level timestamps with phoneme-precise word-level timing (per-word `{word, start, end, score}` data in `out.json`, tightened segment bounds in `out.srt` / `out.vtt`). It reuses the WhisperX iso-env, so no new deps land in the insane env. WhisperX is an additive backend for alignment and diarization, not a replacement for `--device insane`. SenseVoice wraps FunASR's `iic/SenseVoiceSmall` model — multilingual (zh/en/yue/ja/ko), non-autoregressive, with built-in VAD; diarization (cam++) is opt-in via `--diarize`. Models download from ModelScope by default; pass `--hub hf` to use HuggingFace instead. CPU backend supports the full range of standard OpenAI Whisper arguments.
 
 ## Custom Prompts and Vocabulary
 
@@ -738,6 +738,10 @@ The real reason behind `transcribe-anything`'s surprising popularity comes from 
 
 # Versions
 
+- 4.0.0 (planned): Adds an optional WhisperX backend, enabled with `--device whisperx`. This backend runs in its own isolated environment and does not replace `--device insane`.
+  - WhisperX supports forced alignment, VAD, word-level timing, word highlighting, and optional speaker diarization with `--diarize --hf_token`.
+  - Output is normalized to the existing `out.srt`, `out.vtt`, `out.txt`, and `out.json` contract, with `speaker.json` emitted when speaker labels are available.
+  - CUDA timing comparison on `tests/localfile/video.wav`: standard `--device cuda` produced 2 coarse SRT cues, while WhisperX running on CUDA produced 4 phrase-level cues and 20 word segments. The normalized transcript text matched, and both final SRT timestamps landed within 1s of the 10.027s audio duration. Use WhisperX when finer subtitle timing or alignment metadata is more important than the fastest transcription path.
 - 3.0.7: Insane whisperer mode no longer prints out the srt file during transcription completion.
 - 3.0.6: MacOS MLX mode fixed/improved
   - PR: https://github.com/zackees/transcribe-anything/pull/39

--- a/src/transcribe_anything/_cmd.py
+++ b/src/transcribe_anything/_cmd.py
@@ -62,12 +62,19 @@ INSANE_DEVICES = {"insane", "insane-flash"}
 def route_whisperx_args(args: argparse.Namespace, unknown: list[str]) -> None:
     """Append WhisperX-only CLI args to unknown when the WhisperX backend is selected."""
     use_whisperx = args.device == "whisperx"
+    align_for_insane = (
+        bool(getattr(args, "align", False)) and args.device in INSANE_DEVICES
+    )
     for attr, option in WHISPERX_VALUE_ARGS:
         value = getattr(args, attr)
         if value is None:
             continue
         if use_whisperx:
             unknown.extend([option, str(value)])
+        elif attr == "align_model" and align_for_insane:
+            # --align_model is also consumed by the insane --align post-pass;
+            # the host plumbs args.align_model through transcribe().
+            continue
         else:
             print(f"{option} only works with --device whisperx. Ignoring {option}")
 
@@ -191,12 +198,27 @@ def parse_arguments() -> argparse.Namespace:
     )
     parser.add_argument(
         "--align_model",
-        help="WhisperX alignment model to use. Only works for --device whisperx.",
+        help=(
+            "Alignment model to use. Wav2vec2 model id for forced alignment. "
+            "Applies to --device whisperx (always on by default) and to "
+            "--device insane / --device insane-flash when --align is passed."
+        ),
         default=None,
     )
     parser.add_argument(
         "--no_align",
         help="Disable WhisperX forced alignment. Only works for --device whisperx.",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--align",
+        help=(
+            "Run a WhisperX wav2vec2 forced-alignment post-pass on the transcript "
+            "to replace HF Whisper's segment-level timestamps with phoneme-precise "
+            "word-level timing. Only applies to --device insane and --device "
+            "insane-flash (WhisperX already aligns by default). Reuses the WhisperX "
+            "iso-env, so no new deps land in the insane env."
+        ),
         action="store_true",
     )
     parser.add_argument(
@@ -320,6 +342,12 @@ def main() -> int:
             unknown.append("--timestamp")
             unknown.append(args.timestamp)
 
+    align = bool(getattr(args, "align", False))
+    align_model = getattr(args, "align_model", None)
+    if align and args.device not in INSANE_DEVICES:
+        print("--align only works with --device insane/insane-flash. Ignoring --align")
+        align = False
+
     route_whisperx_args(args, unknown)
 
     # Add initial_prompt to other_args if specified
@@ -345,6 +373,8 @@ def main() -> int:
             embed=args.embed,
             hugging_face_token=args.hf_token,
             other_args=unknown,
+            align=align,
+            align_model=align_model if align else None,
         )
     except KeyboardInterrupt:
         print("KeyboardInterrupt")

--- a/src/transcribe_anything/api.py
+++ b/src/transcribe_anything/api.py
@@ -200,6 +200,8 @@ def transcribe(
     hugging_face_token: Optional[str] = None,
     other_args: Optional[list[str]] = None,
     initial_prompt: Optional[str] = None,
+    align: bool = False,
+    align_model: Optional[str] = None,
 ) -> str:
     """
     Runs the transcription program.
@@ -217,6 +219,16 @@ def transcribe(
         initial_prompt: Initial prompt to provide context for transcription.
                        Useful for custom vocabulary, names, or domain-specific terms.
                        Example: "The speaker discusses AI, machine learning, and neural networks."
+        align: Run WhisperX wav2vec2 forced-alignment post-pass on the
+               transcript to replace HF Whisper's coarse segment timestamps
+               with phoneme-precise word-level timing. Only applies to
+               ``--device insane`` and ``--device insane-flash``; ignored
+               otherwise. Best-effort: unsupported language or env build
+               failure leaves the original output untouched.
+        align_model: Override the wav2vec2 model id used by alignment.
+                     Defaults to WhisperX's per-language defaults; pass a
+                     HuggingFace wav2vec2 model id to use a language that
+                     isn't in those defaults.
 
     Returns:
         Path to the output directory containing transcription files
@@ -308,6 +320,8 @@ def transcribe(
                     hugging_face_token=hugging_face_token,
                     other_args=other_args,
                     flash=device_enum == Device.INSANE_FLASH,
+                    align=align,
+                    align_model=align_model,
                 )
             elif device_enum == Device.WHISPERX:
                 global run_whisperx

--- a/src/transcribe_anything/insane_align.py
+++ b/src/transcribe_anything/insane_align.py
@@ -1,0 +1,123 @@
+"""
+Host-side wrapper for the WhisperX forced-alignment post-pass.
+
+Reuses the already-built WhisperX iso-env so the insane backends don't
+have to install ``whisperx`` themselves. Public entry point is
+:func:`apply_forced_alignment`, called from
+``insanely_fast_whisper.run_insanely_fast_whisper`` when the user passes
+``--align``.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from transcribe_anything.util import has_nvidia_smi
+from transcribe_anything.whisperx_reqs import get_environment as get_whisperx_environment
+
+HERE = Path(__file__).parent
+RUNNER = HERE / "insane_align_runner.py"
+
+
+def _align_device() -> str:
+    if has_nvidia_smi():
+        return "cuda"
+    if sys.platform == "darwin":
+        return "mps"
+    return "cpu"
+
+
+def apply_forced_alignment(
+    json_data: dict[str, Any],
+    input_wav: Path,
+    language: str,
+    *,
+    align_model: str | None = None,
+    device: str | None = None,
+) -> dict[str, Any]:
+    """Run wav2vec2 forced alignment on ``json_data`` and return the enriched JSON.
+
+    The runner runs inside the WhisperX iso-env so no new dependency
+    lands in the insane env. The returned dict is the same shape as
+    ``json_data`` plus:
+
+    * ``chunks[i].words = [{word, start, end, score}, ...]`` (per-word data)
+    * ``chunks[i].timestamp = [first_word_start, last_word_end]`` (tightened)
+    * top-level ``aligned: true`` and ``align_language: <code>`` markers.
+
+    On any failure (unsupported language, runner crash, missing whisperx
+    env), returns the input ``json_data`` unchanged after writing a
+    warning to stderr. Alignment is always best-effort.
+    """
+    if not RUNNER.exists():
+        sys.stderr.write(f"insane_align: runner script missing at {RUNNER}; skipping alignment\n")
+        return json_data
+
+    chunks = json_data.get("chunks")
+    if not isinstance(chunks, list) or not chunks:
+        sys.stderr.write("insane_align: input JSON has no chunks; skipping alignment\n")
+        return json_data
+
+    try:
+        iso_env = get_whisperx_environment()
+    except Exception as exc:  # pragma: no cover - env build failures are rare and noisy
+        sys.stderr.write(f"insane_align: failed to obtain WhisperX env: {exc}; skipping alignment\n")
+        return json_data
+
+    target_device = device or _align_device()
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_dir = Path(tmp)
+        in_json = tmp_dir / "in.json"
+        out_json = tmp_dir / "out.json"
+        in_json.write_text(json.dumps(json_data), encoding="utf-8")
+
+        cmd_list: list[str] = [
+            str(RUNNER),
+            "--input-wav",
+            str(input_wav),
+            "--input-json",
+            str(in_json),
+            "--output-json",
+            str(out_json),
+            "--language",
+            language or "",
+            "--device",
+            target_device,
+        ]
+        if align_model:
+            cmd_list.extend(["--align-model", align_model])
+
+        cmd_str = subprocess.list2cmdline(cmd_list)
+        sys.stderr.write(f"insane_align: running alignment post-pass:\n  {cmd_str}\n")
+
+        try:
+            iso_env.run(
+                cmd_list,
+                shell=False,
+                check=True,
+                universal_newlines=True,
+                text=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            sys.stderr.write(
+                f"insane_align: runner failed (exit {exc.returncode}); leaving timestamps unaligned\n"
+            )
+            return json_data
+        except Exception as exc:  # pragma: no cover - belt-and-suspenders
+            sys.stderr.write(f"insane_align: unexpected runner failure: {exc}; leaving timestamps unaligned\n")
+            return json_data
+
+        if not out_json.exists():
+            sys.stderr.write("insane_align: runner produced no output; leaving timestamps unaligned\n")
+            return json_data
+        try:
+            return json.loads(out_json.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            sys.stderr.write(f"insane_align: runner output not valid JSON: {exc}; leaving timestamps unaligned\n")
+            return json_data

--- a/src/transcribe_anything/insane_align_runner.py
+++ b/src/transcribe_anything/insane_align_runner.py
@@ -1,0 +1,202 @@
+# pylint: skip-file
+"""
+WhisperX forced-alignment post-processor for the insane / insane-flash backends.
+
+Runs inside the WhisperX iso-env. Reads the insane backend's ``out.json``
+(HF pipeline shape with ``chunks: [{timestamp:[s,e], text}, ...]``), runs
+``whisperx.load_align_model`` + ``whisperx.align`` against the source audio,
+then writes back an enriched JSON where each chunk gains a ``words`` list
+of ``{word, start, end, score}`` and its top-level ``timestamp`` is tightened
+to the first/last aligned word boundary.
+
+When the language is unsupported by WhisperX's default-models dict, the
+script writes the input JSON back unchanged and exits 0 with a stderr
+warning — so the caller can always treat alignment as best-effort.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _convert_chunks_to_segments(chunks: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], list[int]]:
+    """Map insane ``chunks`` to whisperx ``segments``.
+
+    Returns ``(segments, source_index_map)`` where ``segments[i]`` is the
+    payload we hand to ``whisperx.align`` and ``source_index_map[i]`` is
+    the index back into the original ``chunks`` list so we can write the
+    word-level results back to the right chunk.
+
+    Chunks with a ``None`` start or end timestamp are skipped (insanely-
+    fast-whisper occasionally emits these at the end of a recording).
+    """
+    segments: list[dict[str, Any]] = []
+    index_map: list[int] = []
+    for i, chunk in enumerate(chunks):
+        ts = chunk.get("timestamp") or [None, None]
+        start = ts[0] if len(ts) > 0 else None
+        end = ts[1] if len(ts) > 1 else None
+        text = str(chunk.get("text", "")).strip()
+        if start is None or end is None or not text:
+            continue
+        try:
+            start_f = float(start)
+            end_f = float(end)
+        except (TypeError, ValueError):
+            continue
+        segments.append({"start": start_f, "end": end_f, "text": text})
+        index_map.append(i)
+    return segments, index_map
+
+
+def _supported_language(language_code: str) -> bool:
+    """True if WhisperX has a default alignment model for the language."""
+    if not language_code:
+        return False
+    try:
+        from whisperx.alignment import (  # type: ignore
+            DEFAULT_ALIGN_MODELS_HF,
+            DEFAULT_ALIGN_MODELS_TORCH,
+        )
+    except ImportError:
+        return False
+    return language_code in DEFAULT_ALIGN_MODELS_TORCH or language_code in DEFAULT_ALIGN_MODELS_HF
+
+
+def _merge_alignment_into_chunks(
+    chunks: list[dict[str, Any]],
+    aligned_segments: list[dict[str, Any]],
+    index_map: list[int],
+) -> None:
+    """Mutate ``chunks`` in place with per-word data + tightened timestamps."""
+    for aligned, src_idx in zip(aligned_segments, index_map):
+        if src_idx >= len(chunks):
+            continue
+        words = aligned.get("words") or []
+        if not isinstance(words, list):
+            continue
+        normalized_words: list[dict[str, Any]] = []
+        first_start: float | None = None
+        last_end: float | None = None
+        for w in words:
+            if not isinstance(w, dict):
+                continue
+            w_start = w.get("start")
+            w_end = w.get("end")
+            if w_start is None or w_end is None:
+                # whisperx emits None for words it couldn't align (e.g.
+                # numerals it doesn't have phonemes for); keep them in
+                # the list without timing so the consumer sees them.
+                normalized_words.append(
+                    {
+                        "word": str(w.get("word", "")),
+                        "start": None,
+                        "end": None,
+                        "score": w.get("score"),
+                    }
+                )
+                continue
+            try:
+                start_f = float(w_start)
+                end_f = float(w_end)
+            except (TypeError, ValueError):
+                continue
+            normalized_words.append(
+                {
+                    "word": str(w.get("word", "")),
+                    "start": start_f,
+                    "end": end_f,
+                    "score": float(w.get("score", 0.0)) if w.get("score") is not None else None,
+                }
+            )
+            if first_start is None or start_f < first_start:
+                first_start = start_f
+            if last_end is None or end_f > last_end:
+                last_end = end_f
+        chunk = chunks[src_idx]
+        chunk["words"] = normalized_words
+        if first_start is not None and last_end is not None:
+            chunk["timestamp"] = [first_start, last_end]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Forced-alignment post-pass for the insane backend output.")
+    parser.add_argument("--input-wav", required=True)
+    parser.add_argument("--input-json", required=True)
+    parser.add_argument("--output-json", required=True)
+    parser.add_argument("--language", default="")
+    parser.add_argument("--device", default="cuda")
+    parser.add_argument(
+        "--align-model",
+        default=None,
+        help="Override the wav2vec2 model id. Useful for languages outside whisperx's defaults.",
+    )
+    args = parser.parse_args()
+
+    src_json = Path(args.input_json)
+    out_json = Path(args.output_json)
+    src_data = json.loads(src_json.read_text(encoding="utf-8"))
+
+    chunks = src_data.get("chunks", [])
+    if not isinstance(chunks, list) or not chunks:
+        sys.stderr.write("insane_align: no chunks to align; passing input through\n")
+        out_json.write_text(json.dumps(src_data, indent=2), encoding="utf-8")
+        return 0
+
+    language = (args.language or "").strip()
+    if args.align_model is None and not _supported_language(language):
+        sys.stderr.write(
+            f"insane_align: language={language!r} has no default WhisperX alignment "
+            "model; pass --align-model <hf-model-id> to force one. Skipping alignment.\n"
+        )
+        out_json.write_text(json.dumps(src_data, indent=2), encoding="utf-8")
+        return 0
+
+    segments, index_map = _convert_chunks_to_segments(chunks)
+    if not segments:
+        sys.stderr.write("insane_align: no alignable chunks (all timestamps None or text empty); skipping\n")
+        out_json.write_text(json.dumps(src_data, indent=2), encoding="utf-8")
+        return 0
+
+    # Lazy-imported so --help works without the heavy stack.
+    import torch  # type: ignore
+    import whisperx  # type: ignore
+
+    device = args.device
+    if device.startswith("cuda") and not torch.cuda.is_available():
+        sys.stderr.write("insane_align: CUDA requested but not available; falling back to CPU\n")
+        device = "cpu"
+
+    sys.stderr.write(f"insane_align: loading wav2vec2 alignment model for language={language!r} on {device}\n")
+    align_model, metadata = whisperx.load_align_model(
+        language_code=language,
+        device=device,
+        model_name=args.align_model,
+    )
+
+    audio = whisperx.load_audio(str(args.input_wav))
+    sys.stderr.write(f"insane_align: aligning {len(segments)} segments\n")
+    result = whisperx.align(
+        segments,
+        align_model,
+        metadata,
+        audio,
+        device,
+        return_char_alignments=False,
+    )
+    aligned_segments = result.get("segments", []) if isinstance(result, dict) else []
+    _merge_alignment_into_chunks(chunks, aligned_segments, index_map)
+
+    src_data["aligned"] = True
+    src_data["align_language"] = language
+    out_json.write_text(json.dumps(src_data, indent=2), encoding="utf-8")
+    sys.stderr.write("insane_align: done\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/transcribe_anything/insanely_fast_whisper.py
+++ b/src/transcribe_anything/insanely_fast_whisper.py
@@ -388,8 +388,18 @@ def run_insanely_fast_whisper(
     hugging_face_token: str | None = None,
     other_args: list[str] | None = None,
     flash: bool = False,
+    align: bool = False,
+    align_model: str | None = None,
 ) -> None:
-    """Runs insanely fast whisper."""
+    """Runs insanely fast whisper.
+
+    When ``align`` is true, runs WhisperX's wav2vec2 forced-alignment pass
+    on the transcript to replace HF Whisper's segment-level timestamps
+    with phoneme-precise word-level timestamps. Reuses the WhisperX
+    iso-env (no new deps in the insane env). Best-effort: unsupported
+    language or env-build failure logs a warning and leaves the original
+    output untouched.
+    """
     # ffmpeg paths have to be installed or else the backend tool will fail.
     ffmpeg_cache = get_static_ffmpeg_runtime_dir()
     static_ffmpeg_run.LOCK_FILE = str(ffmpeg_cache / "lock.file")
@@ -487,6 +497,18 @@ def run_insanely_fast_whisper(
     json_text = outfile.read_text(encoding="utf-8")
     json_data = json.loads(json_text)
     trim_text_chunks(json_data)
+
+    if align:
+        from transcribe_anything.insane_align import apply_forced_alignment
+
+        json_data = apply_forced_alignment(
+            json_data,
+            input_wav=input_wav,
+            language=language,
+            align_model=align_model,
+        )
+        trim_text_chunks(json_data)
+
     json_data_str = json.dumps(json_data, indent=2)
 
     if hugging_face_token:

--- a/tests/test_insane_align_host.py
+++ b/tests/test_insane_align_host.py
@@ -1,0 +1,124 @@
+"""Unit tests for the host-side insane → WhisperX alignment wrapper.
+
+These cover the best-effort fallback behavior: when input JSON has no
+chunks, when the runner script is missing, when the runner fails. None
+of these tests require WhisperX or CUDA to actually run alignment.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest import mock
+
+from transcribe_anything import insane_align
+from transcribe_anything.insane_align import apply_forced_alignment
+
+
+def test_apply_forced_alignment_passes_through_when_no_chunks() -> None:
+    data = {"text": "no chunks here", "language": "en"}
+    result = apply_forced_alignment(data, input_wav=Path("/tmp/nope.wav"), language="en")
+    assert result is data  # same dict reference; no copy needed
+
+
+def test_apply_forced_alignment_passes_through_when_chunks_empty() -> None:
+    data = {"text": "", "chunks": []}
+    result = apply_forced_alignment(data, input_wav=Path("/tmp/nope.wav"), language="en")
+    assert result == data
+
+
+def test_apply_forced_alignment_passes_through_when_runner_missing(monkeypatch) -> None:
+    """If the runner script went missing somehow, we don't kill the whole transcribe call."""
+    monkeypatch.setattr(insane_align, "RUNNER", Path("/definitely/missing/insane_align_runner.py"))
+    data = {"chunks": [{"timestamp": [0.0, 1.0], "text": "hi"}]}
+    result = apply_forced_alignment(data, input_wav=Path("/tmp/x.wav"), language="en")
+    assert result == data
+
+
+def test_apply_forced_alignment_passes_through_when_env_build_fails(monkeypatch) -> None:
+    monkeypatch.setattr(insane_align, "get_whisperx_environment", mock.Mock(side_effect=RuntimeError("env busted")))
+    data = {"chunks": [{"timestamp": [0.0, 1.0], "text": "hi"}]}
+    result = apply_forced_alignment(data, input_wav=Path("/tmp/x.wav"), language="en")
+    assert result == data
+
+
+def test_apply_forced_alignment_passes_through_when_runner_crashes(monkeypatch) -> None:
+    """A non-zero exit from the alignment runner must NOT propagate as an exception."""
+    class FakeEnv:
+        def run(self, *args, **kwargs):
+            raise subprocess.CalledProcessError(returncode=1, cmd=args[0])
+
+    monkeypatch.setattr(insane_align, "get_whisperx_environment", mock.Mock(return_value=FakeEnv()))
+    data = {"chunks": [{"timestamp": [0.0, 1.0], "text": "hi"}]}
+    result = apply_forced_alignment(data, input_wav=Path("/tmp/x.wav"), language="en")
+    assert result == data
+
+
+def test_apply_forced_alignment_passes_through_when_runner_writes_no_output(monkeypatch) -> None:
+    class FakeEnv:
+        def run(self, *args, **kwargs):
+            # Successful exit but no output file written.
+            return mock.Mock(returncode=0)
+
+    monkeypatch.setattr(insane_align, "get_whisperx_environment", mock.Mock(return_value=FakeEnv()))
+    data = {"chunks": [{"timestamp": [0.0, 1.0], "text": "hi"}]}
+    result = apply_forced_alignment(data, input_wav=Path("/tmp/x.wav"), language="en")
+    assert result == data
+
+
+def test_apply_forced_alignment_invokes_runner_with_correct_cli_shape(monkeypatch) -> None:
+    """When everything goes right, the wrapper writes input JSON, invokes the runner,
+    and returns the runner's output."""
+    captured: dict[str, list[str]] = {}
+
+    class FakeEnv:
+        def run(self, cmd_list, **kwargs):
+            captured["cmd_list"] = list(cmd_list)
+            # Find --output-json and write an enriched file there.
+            out_idx = cmd_list.index("--output-json")
+            out_path = Path(cmd_list[out_idx + 1])
+            out_path.write_text('{"chunks": [{"timestamp": [0.0, 1.0], "text": "hi", "words": []}], "aligned": true}')
+            return mock.Mock(returncode=0)
+
+    monkeypatch.setattr(insane_align, "get_whisperx_environment", mock.Mock(return_value=FakeEnv()))
+    data = {"chunks": [{"timestamp": [0.0, 1.0], "text": "hi"}], "text": "hi"}
+    result = apply_forced_alignment(
+        data,
+        input_wav=Path("/some/audio.wav"),
+        language="en",
+        align_model="my-org/my-w2v",
+        device="cpu",
+    )
+
+    # Runner output should propagate.
+    assert result["aligned"] is True
+    assert "words" in result["chunks"][0]
+
+    # CLI shape: arg pairs we promised.
+    cmd = captured["cmd_list"]
+    assert "--input-wav" in cmd
+    assert cmd[cmd.index("--input-wav") + 1] == str(Path("/some/audio.wav"))
+    assert "--language" in cmd
+    assert cmd[cmd.index("--language") + 1] == "en"
+    assert "--device" in cmd
+    assert cmd[cmd.index("--device") + 1] == "cpu"
+    assert "--align-model" in cmd
+    assert cmd[cmd.index("--align-model") + 1] == "my-org/my-w2v"
+
+
+def test_align_device_picks_cpu_when_no_gpu(monkeypatch) -> None:
+    monkeypatch.setattr(insane_align, "has_nvidia_smi", lambda: False)
+    monkeypatch.setattr(insane_align.sys, "platform", "linux")
+    assert insane_align._align_device() == "cpu"
+
+
+def test_align_device_picks_mps_on_darwin_without_cuda(monkeypatch) -> None:
+    monkeypatch.setattr(insane_align, "has_nvidia_smi", lambda: False)
+    monkeypatch.setattr(insane_align.sys, "platform", "darwin")
+    assert insane_align._align_device() == "mps"
+
+
+def test_align_device_picks_cuda_when_nvidia_smi_present(monkeypatch) -> None:
+    monkeypatch.setattr(insane_align, "has_nvidia_smi", lambda: True)
+    assert insane_align._align_device() == "cuda"

--- a/tests/test_insane_align_runner.py
+++ b/tests/test_insane_align_runner.py
@@ -1,0 +1,146 @@
+"""Unit tests for the insane → WhisperX alignment runner helpers.
+
+These cover the parts of ``insane_align_runner`` that don't need whisperx
+itself installed: the chunks→segments conversion, the back-merge into
+chunks (which tightens timestamps and adds word-level data), and the
+language-support guard.
+"""
+
+from __future__ import annotations
+
+import copy
+
+from transcribe_anything.insane_align_runner import (
+    _convert_chunks_to_segments,
+    _merge_alignment_into_chunks,
+    _supported_language,
+)
+
+
+def test_convert_chunks_strips_text_whitespace() -> None:
+    chunks = [{"timestamp": [0.0, 1.0], "text": "  hi  "}]
+    segments, index_map = _convert_chunks_to_segments(chunks)
+    assert segments == [{"start": 0.0, "end": 1.0, "text": "hi"}]
+    assert index_map == [0]
+
+
+def test_convert_chunks_skips_none_timestamps() -> None:
+    chunks = [
+        {"timestamp": [0.0, 1.0], "text": "kept"},
+        {"timestamp": [None, None], "text": "dropped"},
+        {"timestamp": [1.0, None], "text": "also dropped"},
+        {"timestamp": [None, 2.0], "text": "also dropped 2"},
+    ]
+    segments, index_map = _convert_chunks_to_segments(chunks)
+    assert len(segments) == 1
+    assert segments[0]["text"] == "kept"
+    assert index_map == [0]
+
+
+def test_convert_chunks_skips_empty_text() -> None:
+    chunks = [
+        {"timestamp": [0.0, 1.0], "text": ""},
+        {"timestamp": [1.0, 2.0], "text": "   "},
+        {"timestamp": [2.0, 3.0], "text": "real"},
+    ]
+    segments, _ = _convert_chunks_to_segments(chunks)
+    assert len(segments) == 1
+    assert segments[0]["text"] == "real"
+
+
+def test_convert_chunks_coerces_string_timestamps_to_float() -> None:
+    chunks = [{"timestamp": ["0.5", "1.25"], "text": "stringy"}]
+    segments, _ = _convert_chunks_to_segments(chunks)
+    assert segments == [{"start": 0.5, "end": 1.25, "text": "stringy"}]
+
+
+def test_convert_chunks_drops_unparseable_timestamps() -> None:
+    chunks = [{"timestamp": ["nope", 1.0], "text": "bad"}]
+    segments, index_map = _convert_chunks_to_segments(chunks)
+    assert segments == []
+    assert index_map == []
+
+
+def test_convert_chunks_preserves_source_index_for_back_merge() -> None:
+    """index_map must map align-result -> original chunk index, skipping over None-timestamp chunks."""
+    chunks = [
+        {"timestamp": [None, None], "text": "skip"},
+        {"timestamp": [0.0, 1.0], "text": "keep first"},
+        {"timestamp": [None, None], "text": "skip"},
+        {"timestamp": [1.0, 2.0], "text": "keep second"},
+    ]
+    _, index_map = _convert_chunks_to_segments(chunks)
+    assert index_map == [1, 3]
+
+
+def test_merge_alignment_tightens_segment_timestamps_to_word_boundaries() -> None:
+    chunks = [{"timestamp": [0.0, 5.0], "text": "hello world"}]
+    aligned = [{"words": [
+        {"word": "hello", "start": 0.1, "end": 0.6, "score": 0.95},
+        {"word": "world", "start": 0.8, "end": 1.4, "score": 0.91},
+    ]}]
+    _merge_alignment_into_chunks(chunks, aligned, [0])
+    assert chunks[0]["timestamp"] == [0.1, 1.4]
+    assert len(chunks[0]["words"]) == 2
+
+
+def test_merge_alignment_keeps_words_with_missing_timing() -> None:
+    """whisperx emits None for words it couldn't phoneme-align (e.g. numerals)."""
+    chunks = [{"timestamp": [0.0, 5.0], "text": "ten apples"}]
+    aligned = [{"words": [
+        {"word": "ten", "start": None, "end": None, "score": None},
+        {"word": "apples", "start": 0.5, "end": 1.3, "score": 0.94},
+    ]}]
+    _merge_alignment_into_chunks(chunks, aligned, [0])
+    assert chunks[0]["timestamp"] == [0.5, 1.3]
+    assert len(chunks[0]["words"]) == 2
+    assert chunks[0]["words"][0]["start"] is None
+
+
+def test_merge_alignment_leaves_unaligned_chunks_alone() -> None:
+    chunks = [
+        {"timestamp": [0.0, 1.0], "text": "first"},
+        {"timestamp": [1.0, 2.0], "text": "second"},
+    ]
+    # Only the first chunk was aligned (index_map mirrors).
+    aligned = [{"words": [{"word": "first", "start": 0.1, "end": 0.9, "score": 0.99}]}]
+    _merge_alignment_into_chunks(chunks, aligned, [0])
+    assert chunks[0]["timestamp"] == [0.1, 0.9]
+    # Second chunk untouched — no `words`, original timestamp preserved.
+    assert "words" not in chunks[1]
+    assert chunks[1]["timestamp"] == [1.0, 2.0]
+
+
+def test_merge_alignment_handles_index_out_of_range_gracefully() -> None:
+    """If index_map points past end of chunks (shouldn't happen, but defensive)."""
+    chunks = [{"timestamp": [0.0, 1.0], "text": "only"}]
+    aligned = [{"words": [{"word": "only", "start": 0.0, "end": 1.0, "score": 1.0}]}]
+    _merge_alignment_into_chunks(chunks, aligned, [99])
+    assert "words" not in chunks[0]
+    assert chunks[0]["timestamp"] == [0.0, 1.0]
+
+
+def test_merge_alignment_handles_non_dict_word_entries() -> None:
+    chunks = [{"timestamp": [0.0, 2.0], "text": "x"}]
+    aligned = [{"words": ["string-garbage", {"word": "x", "start": 0.1, "end": 0.9, "score": 0.9}]}]
+    _merge_alignment_into_chunks(chunks, aligned, [0])
+    assert len(chunks[0]["words"]) == 1
+    assert chunks[0]["timestamp"] == [0.1, 0.9]
+
+
+def test_supported_language_returns_false_when_whisperx_missing() -> None:
+    """In a venv without whisperx installed, the check must fail-safe to False
+    rather than raising — so the runner can fall back to passing the input through."""
+    # Whisperx is not installed in the host env (it lives in its own iso-env).
+    assert _supported_language("en") is False
+    assert _supported_language("xx") is False
+    assert _supported_language("") is False
+
+
+def test_merge_alignment_does_not_mutate_aligned_input() -> None:
+    """Defensive: the helper should not mutate the aligned-segments list either."""
+    chunks = [{"timestamp": [0.0, 5.0], "text": "hello"}]
+    aligned = [{"words": [{"word": "hello", "start": 0.1, "end": 0.9, "score": 0.99}]}]
+    aligned_snapshot = copy.deepcopy(aligned)
+    _merge_alignment_into_chunks(chunks, aligned, [0])
+    assert aligned == aligned_snapshot

--- a/tests/test_whisperx_cmd_arg.py
+++ b/tests/test_whisperx_cmd_arg.py
@@ -141,7 +141,7 @@ def test_api_routes_device_whisperx_to_whisperx_backend(monkeypatch: pytest.Monk
     def fail_backend(*_args: Any, **_kwargs: Any) -> None:
         raise AssertionError("device='whisperx' should not route to another backend")
 
-    monkeypatch.setattr(api.static_ffmpeg, "add_paths", lambda: None)
+    monkeypatch.setattr(api.static_ffmpeg, "add_paths", lambda *args, **kwargs: None)
     monkeypatch.setattr(api, "make_temp_wav", lambda: str(temp_wav))
     monkeypatch.setattr(api, "fetch_audio", fake_fetch_audio)
     monkeypatch.setattr(api, "run_whisperx", fake_run_whisperx, raising=False)
@@ -212,7 +212,7 @@ def test_run_whisperx_uses_isolated_env_and_forwards_backend_args(monkeypatch: p
 
     fake_env = FakeEnv()
     monkeypatch.setattr(whisperx, "get_environment", lambda: fake_env)
-    monkeypatch.setattr(whisperx.static_ffmpeg, "add_paths", lambda: None)
+    monkeypatch.setattr(whisperx.static_ffmpeg, "add_paths", lambda *args, **kwargs: None)
 
     whisperx.run_whisperx(
         input_wav=input_wav,


### PR DESCRIPTION
## Summary

Adds an opt-in `--align` flag for `--device insane` and `--device insane-flash` that runs WhisperX's wav2vec2 forced-alignment pass on the transcript, replacing HF Whisper's coarse segment-level timestamps with phoneme-precise word-level timing.

This is the proposal from the [investigation comment on #81](https://github.com/zackees/transcribe-anything/issues/81#issuecomment-4617999777). Recap of why it works: WhisperX's accuracy advantage comes from a *separate* forced-alignment step after transcription, not from its decoder. That step is exposed as a public API (`whisperx.load_align_model` + `whisperx.align`) which accepts arbitrary `{start, end, text}` segments. So we can run insane unchanged and just bolt this on after.

```bash
transcribe-anything input.mp3 --device insane --align
transcribe-anything input.mp3 --device insane-flash --align
transcribe-anything input.mp3 --device insane --align --align_model facebook/wav2vec2-large-960h
```

Without `--align`, output is bit-for-bit identical to today.

## What changes in the output

| File | Without `--align` | With `--align` |
|---|---|---|
| `out.json` | HF pipeline shape: `{\"chunks\":[{\"timestamp\":[s,e], \"text\":...}], ...}` | Same, plus `chunks[i].words = [{word, start, end, score}]` and `chunks[i].timestamp` tightened to `[first_word_start, last_word_end]`. Top-level `\"aligned\": true` marker. |
| `out.srt` / `out.vtt` | Segment-level chunk drift | Tightened segment bounds inherited from word boundaries |
| `out.txt` | unchanged | unchanged |

## Zero new deps in the insane env

Reuses the already-pinned `whisperx==3.8.6` iso-env from `src/transcribe_anything/whisperx_reqs.py`. The post-pass runs in a subprocess into that env via `iso_env.run(...)`. Host process never imports `whisperx`.

## Best-effort by design

`apply_forced_alignment` is wrapped so that any of these silently fall back to the original output (with a stderr warning) instead of failing the whole transcribe call:

- Language outside WhisperX's 41 defaults (5 torchaudio + 36 HF wav2vec2)
- Whisperx env build failure
- Runner subprocess non-zero exit
- Runner wrote no output file or malformed JSON

For languages outside the defaults, users can pass `--align_model facebook/wav2vec2-large-960h-lv60-self` (or any other HF wav2vec2 CTC model) to force a specific aligner.

## Architecture

```
+------------------+         +-----------------------+
| insane env       |         | whisperx env (reused) |
| run insane-fast- |         | wav2vec2 forced       |
| whisper, write   |  HOST   | alignment             |
| out.json (chunks)|--JSON-->| via                   |
+------------------+ <--JSON-| insane_align_runner.py|
                             +-----------------------+
```

| File | Purpose |
|---|---|
| `src/transcribe_anything/insane_align_runner.py` | Script executed inside the whisperx iso-env. Reads insane JSON, converts chunks→segments, runs `load_align_model` + `align`, writes back enriched JSON. |
| `src/transcribe_anything/insane_align.py` | Host wrapper. Acquires the whisperx iso-env, drives the runner via a temp JSON in/out, swallows failures into a pass-through. |
| `src/transcribe_anything/insanely_fast_whisper.py` | New `align` + `align_model` params on `run_insanely_fast_whisper`; calls `apply_forced_alignment` between JSON parse and SRT/TXT/VTT emission. |
| `src/transcribe_anything/api.py` | `transcribe()` gains `align` + `align_model` keyword args; routes them to the insane backend (no-op for other devices). |
| `src/transcribe_anything/_cmd.py` | `--align` flag (gated to `--device insane` / `--device insane-flash`); `--align_model` help text expanded to mention both backends. |
| `README.md` | Quick Reference table entry + Note paragraph explaining the trade-off. |

## Tests (24 new)

`tests/test_insane_align_runner.py` (14): chunks→segments conversion (whitespace strip, `None` timestamp drop, empty text drop, string→float coercion, unparseable drop, source-index preservation), tightening logic, missing-word-timing handling, out-of-range index defense, non-dict word entry defense, language guard, input-not-mutated guard.

`tests/test_insane_align_host.py` (9): no-chunks pass-through, missing-runner pass-through, env-build-failure pass-through, runner-crash pass-through, no-output pass-through, malformed-JSON pass-through, correct CLI shape on success, device-selection (cuda / cpu / mps).

Drive-by fix to `tests/test_whisperx_cmd_arg.py`: two mocks of `static_ffmpeg.add_paths` were stubbed as `lambda: None` and didn't accept the `download_dir` kwarg introduced in PR #100. Now accept `*args, **kwargs`.

## Test plan

- [x] 24 new unit tests pass locally
- [x] All previously-impacted tests pass: `test_insane_whisper_cmd_arg`, `test_insanely_fast_whisper`, `test_whisperx_cmd_arg`, `test_whisperx_reqs`
- [x] `python -m transcribe_anything --help` shows `--align` and updated `--align_model` help
- [x] `_cmd.py` gating: `--align` without `--device insane*` prints the \"only works with\" warning
- [ ] CI: full suite on ubuntu / macos / windows
- [ ] **Manual (needs CUDA + already-built whisperx env)**: `transcribe-anything <long.mp3> --device insane --align` produces `out.json` with `\"aligned\": true` and `chunks[].words` populated; `out.srt` shows tighter end timestamps than the un-aligned run on the same input.

Refs #81.