### PR TITLE
release: 4.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,17 +27,77 @@ Over 800+⭐'s because this program this app just works! Works great for windows
 - **99.9% uptime SLA** with enterprise-grade security (SOC 2, HIPAA, ISO 27001)
 - **One API for all meeting platforms** — no platform-specific integrations required
 
-### New in 4.0! (planned)
+### New in 4.0! 🎉
 
-**Guaranteed FlashAttention backend for CUDA users.**
+**Three new backends, phoneme-precise word-level timestamps for the fast path, and read-only installs.** This is the biggest release since the `--device insane` debut. If you ran 3.2 and squinted at end-of-audio timestamps, this is the one to upgrade to.
 
-The new `--device insane-flash` backend keeps normal `--device insane` unchanged, but creates a separate isolated environment with pinned FlashAttention wheels. On supported NVIDIA CUDA platforms it forces the upstream insanely-fast-whisper `--flash True` path, verifies `flash_attn` and the compiled CUDA extension before transcription starts, and fails early with platform diagnostics when no controlled wheel is available.
+#### 🚀 `--device insane-flash` — guaranteed FlashAttention2 on CUDA
 
-Supported first-pass wheel targets are Windows x86_64, Linux x86_64, and Linux aarch64 on Python 3.11 with `torch==2.7.0+cu128` and `flash-attn==2.8.3`. macOS is not supported for `insane-flash`; Apple Silicon users should use `--device mlx`.
+Same blazing `insanely-fast-whisper` model path as `--device insane`, but in a separate isolated environment with **pinned FlashAttention2 wheels** for Windows x86_64, Linux x86_64, and Linux aarch64 (Python 3.11, `torch==2.7.0+cu128`, `flash-attn==2.8.3`). It verifies `flash_attn` and the compiled CUDA extension *before* transcription starts and fails early with platform diagnostics when no controlled wheel is available. No more sad-path silent fallbacks.
 
 ```bash
 transcribe-anything video.mp4 --device insane-flash --batch-size 8
 ```
+
+#### 🎯 `--align` — phoneme-precise word-level timestamps on `--device insane` / `--device insane-flash`
+
+The HF-pipeline timestamp drift on long audio is **over**. Add `--align` and the transcript gets a WhisperX wav2vec2 forced-alignment post-pass: every chunk grows a `words: [{word, start, end, score}]` array and segment timestamps tighten to first/last-word boundaries. `out.srt` and `out.vtt` inherit the tightened bounds for free. Reuses the WhisperX iso-env, so no new deps in the insane env. Best-effort by design — unsupported language, env build failure, or runner crash falls back to the original output with a stderr warning, never breaks transcription.
+
+```bash
+# Phoneme-precise timestamps on the fast path:
+transcribe-anything video.mp4 --device insane --align
+transcribe-anything video.mp4 --device insane-flash --align
+
+# Force a specific wav2vec2 aligner for languages outside the 41 defaults:
+transcribe-anything video.mp4 --device insane --align --align_model facebook/wav2vec2-large-960h-lv60-self
+```
+
+#### 🎙️ `--device whisperx` — alignment + diarization + word timing as a first-class backend
+
+[WhisperX](https://github.com/m-bain/whisperX) is now bundled as a parallel, additive backend (it does **not** replace `--device insane`). Built-in VAD chunking, wav2vec2 forced alignment, and pyannote diarization — all from one CLI. Use it when you want word-level timestamps and per-speaker labels from a single backend invocation.
+
+```bash
+transcribe-anything video.mp4 --device whisperx --diarize --hf_token <hf_xxxx>
+```
+
+Supports `--compute_type`, `--min_speakers` / `--max_speakers`, `--align_model`, `--no_align`, `--highlight_words`, `--vad_method`, `--chunk_size`.
+
+#### 🌐 `--device sensevoice` — multilingual non-autoregressive, ~5x faster at comparable WER
+
+New isolated-env backend wrapping FunASR's `iic/SenseVoiceSmall` model. **Non-autoregressive** — ~5x faster than `whisper-large-v3` at comparable word-error rate. Multilingual out of the box (`auto`/`zh`/`en`/`yue`/`ja`/`ko`/`nospeech`), built-in `fsmn-vad`, emotion detection, and event-tag postprocessing. Speaker diarization via `cam++` is opt-in with `--diarize`. Models pull from ModelScope by default; pass `--hub hf` for HuggingFace.
+
+```bash
+transcribe-anything video.mp4 --device sensevoice
+transcribe-anything video.mp4 --device sensevoice --diarize --language zh
+```
+
+#### 📦 Read-only installs work now
+
+Backend iso-env venvs and the bundled `static_ffmpeg` binary moved from inside the package directory (`<site-packages>/transcribe_anything/venv/...`) to the user cache directory (`<user_cache_dir>/transcribe-anything/...`). That unblocks Nix-store installs, OS-package installs, multi-user shared installs, baked-into-container installs, and `pip install --target` with a read-only mount. Override the location with `TRANSCRIBE_ANYTHING_CACHE_DIR=/somewhere/writable`.
+
+> **One-time cost on upgrade:** existing 3.2 installs have a venv cache at the *old* path. Those caches are orphaned by this move, so the first run of each backend after upgrade re-downloads its dependencies (~10 GB for `--device insane`). No data loss — just the install-time wheel fetch, once.
+
+#### ❄️ Native Nix flake — community contribution
+
+```bash
+nix run github:zackees/transcribe-anything -- <url-or-file> --device insane
+nix shell github:zackees/transcribe-anything
+nix build .#transcribe-anything
+```
+
+A complete [uv2nix](https://github.com/pyproject-nix/uv2nix)-based Nix flake is now part of the repo, contributed by community member [@eeedean](https://github.com/eeedean) (#68 → #104). One-line install for any Linux / macOS / NixOS user with Nix flakes enabled, the wrapper script puts `ffmpeg` and `uv` on PATH automatically, and the dev shell (`nix develop`) gives you an editable install with `yt-dlp` pre-installed. Pairs perfectly with the read-only-install support above — backend iso-envs land in your user cache, not the immutable Nix store.
+
+#### ☁️ Cloud / Serverless (no local GPU)
+
+If you don't have a local NVIDIA GPU, community member [@victorkjung](https://github.com/victorkjung) maintains a turnkey [RunPod Serverless deployment](https://github.com/victorkjung/transcribe-anything/tree/runpod-integration/runpod). Per-second-billed GPU minutes that scale to zero. See the [Cloud / Serverless](#cloud--serverless-no-local-gpu) section below.
+
+#### 🔒 Security fix
+
+`--hf-token` no longer leaks into stderr or the `OSError("Failed to execute ...")` traceback when the insane backend's subprocess fails. If you ran 3.2 on RunPod, Modal, or any other serverless host that surfaces stdout/stderr or exception messages in job-status APIs, **rotate your HuggingFace token** — older runs may have logged it. Going forward, the token is masked in both the `Running:` banner and the failure traceback. The subprocess itself still receives the real token.
+
+#### 🙏 Thanks
+
+`--device insane-flash`, `--device whisperx`, and the long-form timestamp regression suite were driven by community feedback through the issue tracker. `--device sensevoice` is wired up against FunASR ([FunAudioLLM/SenseVoice](https://github.com/FunAudioLLM/SenseVoice)). `--align` reuses the wav2vec2 forced-alignment work from [m-bain/whisperX](https://github.com/m-bain/whisperX). Special thanks to [@aj47](https://github.com/aj47) for the MLX backend, [@victorkjung](https://github.com/victorkjung) for the RunPod Serverless deployment fork, and everyone who filed issues and PRs since 3.2.
 
 ### New in 3.2!
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "python-dotenv>=1.0.1",
 ]
 # VERSION
-version = "3.2.10"  # Update this manually or configure setuptools-scm for automatic versioning
+version = "4.0.0"  # Update this manually or configure setuptools-scm for automatic versioning
 maintainers = [{ name = "Zachary Vorhies", email = "dont@email.me" }]
 
 [project.urls]

--- a/src/transcribe_anything/_cmd.py
+++ b/src/transcribe_anything/_cmd.py
@@ -62,9 +62,7 @@ INSANE_DEVICES = {"insane", "insane-flash"}
 def route_whisperx_args(args: argparse.Namespace, unknown: list[str]) -> None:
     """Append WhisperX-only CLI args to unknown when the WhisperX backend is selected."""
     use_whisperx = args.device == "whisperx"
-    align_for_insane = (
-        bool(getattr(args, "align", False)) and args.device in INSANE_DEVICES
-    )
+    align_for_insane = bool(getattr(args, "align", False)) and args.device in INSANE_DEVICES
     for attr, option in WHISPERX_VALUE_ARGS:
         value = getattr(args, attr)
         if value is None:

--- a/src/transcribe_anything/api.py
+++ b/src/transcribe_anything/api.py
@@ -26,7 +26,11 @@ from appdirs import user_config_dir  # type: ignore
 from transcribe_anything.audio import fetch_audio
 from transcribe_anything.insanely_fast_whisper import run_insanely_fast_whisper
 from transcribe_anything.logger import log_error
-from transcribe_anything.util import chop_double_extension, get_static_ffmpeg_runtime_dir, sanitize_filename
+from transcribe_anything.util import (
+    chop_double_extension,
+    get_static_ffmpeg_runtime_dir,
+    sanitize_filename,
+)
 from transcribe_anything.whisper import get_computing_device, run_whisper
 from transcribe_anything.whisper_mac import run_whisper_mac_mlx
 

--- a/src/transcribe_anything/insane_align.py
+++ b/src/transcribe_anything/insane_align.py
@@ -18,7 +18,9 @@ from pathlib import Path
 from typing import Any
 
 from transcribe_anything.util import has_nvidia_smi
-from transcribe_anything.whisperx_reqs import get_environment as get_whisperx_environment
+from transcribe_anything.whisperx_reqs import (
+    get_environment as get_whisperx_environment,
+)
 
 HERE = Path(__file__).parent
 RUNNER = HERE / "insane_align_runner.py"
@@ -105,9 +107,7 @@ def apply_forced_alignment(
                 text=True,
             )
         except subprocess.CalledProcessError as exc:
-            sys.stderr.write(
-                f"insane_align: runner failed (exit {exc.returncode}); leaving timestamps unaligned\n"
-            )
+            sys.stderr.write(f"insane_align: runner failed (exit {exc.returncode}); leaving timestamps unaligned\n")
             return json_data
         except Exception as exc:  # pragma: no cover - belt-and-suspenders
             sys.stderr.write(f"insane_align: unexpected runner failure: {exc}; leaving timestamps unaligned\n")

--- a/src/transcribe_anything/insane_align_runner.py
+++ b/src/transcribe_anything/insane_align_runner.py
@@ -149,10 +149,7 @@ def main() -> int:
 
     language = (args.language or "").strip()
     if args.align_model is None and not _supported_language(language):
-        sys.stderr.write(
-            f"insane_align: language={language!r} has no default WhisperX alignment "
-            "model; pass --align-model <hf-model-id> to force one. Skipping alignment.\n"
-        )
+        sys.stderr.write(f"insane_align: language={language!r} has no default WhisperX alignment " "model; pass --align-model <hf-model-id> to force one. Skipping alignment.\n")
         out_json.write_text(json.dumps(src_data, indent=2), encoding="utf-8")
         return 0
 

--- a/src/transcribe_anything/insanely_fast_whisper.py
+++ b/src/transcribe_anything/insanely_fast_whisper.py
@@ -25,7 +25,10 @@ import webvtt  # type: ignore
 from transcribe_anything.cuda_available import CudaInfo
 from transcribe_anything.generate_speaker_json import generate_speaker_json
 from transcribe_anything.insanley_fast_whisper_reqs import get_environment
-from transcribe_anything.util import get_static_ffmpeg_runtime_dir, print_cuda_diagnostics
+from transcribe_anything.util import (
+    get_static_ffmpeg_runtime_dir,
+    print_cuda_diagnostics,
+)
 
 HERE = Path(__file__).parent
 CUDA_INFO: Optional[CudaInfo] = None

--- a/src/transcribe_anything/parse_whisper_options.py
+++ b/src/transcribe_anything/parse_whisper_options.py
@@ -51,10 +51,7 @@ def parse_whisper_options() -> dict:
     instead of Ctrl+C-ing (issue #40).
     """
     if not _whisper_venv_exists():
-        sys.stderr.write(
-            "[transcribe-anything] First-run install in progress; "
-            "downloading the whisper environment can take several minutes.\n"
-        )
+        sys.stderr.write("[transcribe-anything] First-run install in progress; " "downloading the whisper environment can take several minutes.\n")
         sys.stderr.flush()
     env = get_environment()
     result = env.run(

--- a/src/transcribe_anything/sensevoice.py
+++ b/src/transcribe_anything/sensevoice.py
@@ -95,9 +95,7 @@ def run_sensevoice(  # pylint: disable=too-many-arguments,too-many-locals
     passthrough, language_override = _extract_flag_value(passthrough, "--language")
 
     if passthrough:
-        sys.stderr.write(
-            "Warning: ignoring unsupported SenseVoice args: " + " ".join(passthrough) + "\n"
-        )
+        sys.stderr.write("Warning: ignoring unsupported SenseVoice args: " + " ".join(passthrough) + "\n")
 
     env = dict(os.environ)
     env["PYTHONIOENCODING"] = "utf-8"

--- a/src/transcribe_anything/sensevoice_runner.py
+++ b/src/transcribe_anything/sensevoice_runner.py
@@ -83,7 +83,9 @@ def main() -> int:
     # FunASR + ModelScope are imported inside main() so that --help works
     # without pulling them in.
     from funasr import AutoModel  # type: ignore
-    from funasr.utils.postprocess_utils import rich_transcription_postprocess  # type: ignore
+    from funasr.utils.postprocess_utils import (
+        rich_transcription_postprocess,  # type: ignore
+    )
 
     out_dir = Path(args.output_dir)
     out_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_insane_align_host.py
+++ b/tests/test_insane_align_host.py
@@ -45,6 +45,7 @@ def test_apply_forced_alignment_passes_through_when_env_build_fails(monkeypatch)
 
 def test_apply_forced_alignment_passes_through_when_runner_crashes(monkeypatch) -> None:
     """A non-zero exit from the alignment runner must NOT propagate as an exception."""
+
     class FakeEnv:
         def run(self, *args, **kwargs):
             raise subprocess.CalledProcessError(returncode=1, cmd=args[0])

--- a/tests/test_insane_align_runner.py
+++ b/tests/test_insane_align_runner.py
@@ -9,6 +9,7 @@ language-support guard.
 from __future__ import annotations
 
 import copy
+from typing import Any
 
 from transcribe_anything.insane_align_runner import (
     _convert_chunks_to_segments,
@@ -25,7 +26,7 @@ def test_convert_chunks_strips_text_whitespace() -> None:
 
 
 def test_convert_chunks_skips_none_timestamps() -> None:
-    chunks = [
+    chunks: list[dict[str, Any]] = [
         {"timestamp": [0.0, 1.0], "text": "kept"},
         {"timestamp": [None, None], "text": "dropped"},
         {"timestamp": [1.0, None], "text": "also dropped"},
@@ -63,7 +64,7 @@ def test_convert_chunks_drops_unparseable_timestamps() -> None:
 
 def test_convert_chunks_preserves_source_index_for_back_merge() -> None:
     """index_map must map align-result -> original chunk index, skipping over None-timestamp chunks."""
-    chunks = [
+    chunks: list[dict[str, Any]] = [
         {"timestamp": [None, None], "text": "skip"},
         {"timestamp": [0.0, 1.0], "text": "keep first"},
         {"timestamp": [None, None], "text": "skip"},
@@ -75,10 +76,14 @@ def test_convert_chunks_preserves_source_index_for_back_merge() -> None:
 
 def test_merge_alignment_tightens_segment_timestamps_to_word_boundaries() -> None:
     chunks = [{"timestamp": [0.0, 5.0], "text": "hello world"}]
-    aligned = [{"words": [
-        {"word": "hello", "start": 0.1, "end": 0.6, "score": 0.95},
-        {"word": "world", "start": 0.8, "end": 1.4, "score": 0.91},
-    ]}]
+    aligned = [
+        {
+            "words": [
+                {"word": "hello", "start": 0.1, "end": 0.6, "score": 0.95},
+                {"word": "world", "start": 0.8, "end": 1.4, "score": 0.91},
+            ]
+        }
+    ]
     _merge_alignment_into_chunks(chunks, aligned, [0])
     assert chunks[0]["timestamp"] == [0.1, 1.4]
     assert len(chunks[0]["words"]) == 2
@@ -86,11 +91,15 @@ def test_merge_alignment_tightens_segment_timestamps_to_word_boundaries() -> Non
 
 def test_merge_alignment_keeps_words_with_missing_timing() -> None:
     """whisperx emits None for words it couldn't phoneme-align (e.g. numerals)."""
-    chunks = [{"timestamp": [0.0, 5.0], "text": "ten apples"}]
-    aligned = [{"words": [
-        {"word": "ten", "start": None, "end": None, "score": None},
-        {"word": "apples", "start": 0.5, "end": 1.3, "score": 0.94},
-    ]}]
+    chunks: list[dict[str, Any]] = [{"timestamp": [0.0, 5.0], "text": "ten apples"}]
+    aligned: list[dict[str, Any]] = [
+        {
+            "words": [
+                {"word": "ten", "start": None, "end": None, "score": None},
+                {"word": "apples", "start": 0.5, "end": 1.3, "score": 0.94},
+            ]
+        }
+    ]
     _merge_alignment_into_chunks(chunks, aligned, [0])
     assert chunks[0]["timestamp"] == [0.5, 1.3]
     assert len(chunks[0]["words"]) == 2

--- a/tests/test_parse_whisper_options_errors.py
+++ b/tests/test_parse_whisper_options_errors.py
@@ -58,8 +58,7 @@ class ParseWhisperOptionsDiagnosticsTester(unittest.TestCase):
         self.assertNotEqual(
             kwargs.get("stderr"),
             subprocess.PIPE,
-            msg="parse_whisper_options must not redirect stderr to a PIPE; "
-            "uv first-run progress would be hidden (issue #40).",
+            msg="parse_whisper_options must not redirect stderr to a PIPE; " "uv first-run progress would be hidden (issue #40).",
         )
         self.assertFalse(
             kwargs.get("capture_output", False),
@@ -67,10 +66,7 @@ class ParseWhisperOptionsDiagnosticsTester(unittest.TestCase):
         )
 
     def test_happy_path_parses_options(self) -> None:
-        sample_stdout = (
-            "usage: whisper [-h] [--model {tiny,base}] [--language LANG]\n"
-            "  [--task {transcribe,translate}]\n"
-        )
+        sample_stdout = "usage: whisper [-h] [--model {tiny,base}] [--language LANG]\n" "  [--task {transcribe,translate}]\n"
         fake_env = _fake_env(returncode=0, stdout=sample_stdout, stderr="")
         with mock.patch.object(pwo_module, "get_environment", return_value=fake_env):
             data = pwo_module.parse_whisper_options()

--- a/tests/test_sensevoice_reqs.py
+++ b/tests/test_sensevoice_reqs.py
@@ -36,10 +36,7 @@ def test_top_level_dependencies_do_not_leak_sensevoice_stack() -> None:
     dep_names = {_package_name(dep) for dep in deps}
 
     leaked = sorted(HEAVY_BACKEND_DEPS.intersection(dep_names))
-    assert leaked == [], (
-        "SenseVoice backend dependencies belong in sensevoice_reqs.py, "
-        f"not pyproject.toml: {leaked}"
-    )
+    assert leaked == [], "SenseVoice backend dependencies belong in sensevoice_reqs.py, " f"not pyproject.toml: {leaked}"
 
 
 def test_sensevoice_reqs_include_pinned_backend_stack() -> None:

--- a/tests/test_transformers_version_floor.py
+++ b/tests/test_transformers_version_floor.py
@@ -19,7 +19,6 @@ import unittest
 
 from transcribe_anything.insanley_fast_whisper_reqs import _get_reqs_generic
 
-
 TRANSFORMERS_LINE = re.compile(r"^transformers==(?P<v>\d+\.\d+\.\d+)$")
 MIN_VERSION = (4, 53, 0)
 

--- a/tests/test_whisper_mac_tiktoken_pin.py
+++ b/tests/test_whisper_mac_tiktoken_pin.py
@@ -16,7 +16,6 @@ import unittest
 
 from transcribe_anything.whisper_mac import _make_pyproject_toml_content
 
-
 # Matches any tiktoken requirement line, whether pinned, lower-bounded,
 # upper-bounded, or anything in between.
 TIKTOKEN_REQ = re.compile(r'"\s*tiktoken\s*(?P<op>[<>=!~][^"]*)?\s*"')

--- a/uv.lock
+++ b/uv.lock
@@ -575,7 +575,7 @@ wheels = [
 
 [[package]]
 name = "transcribe-anything"
-version = "3.2.10"
+version = "4.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "appdirs" },


### PR DESCRIPTION
## 🎉 4.0.0 — three new backends, phoneme-precise timestamps, read-only installs, Nix flake

Biggest release since the `--device insane` debut. Highlights covered in the README announcement.

### Marquee backends

- **`--device insane-flash`** (#90) — separate iso-env with pinned FlashAttention2 wheels for Windows x86_64, Linux x86_64 / aarch64 on Py3.11 + `torch==2.7.0+cu128`. Fails early with diagnostics instead of silently falling back to a slower path.
- **`--align`** (#102) — opt-in WhisperX wav2vec2 forced-alignment post-pass for `--device insane` / `--device insane-flash`. Per-word `{word, start, end, score}` data + tightened segment timestamps. Reuses the WhisperX iso-env — **no new deps in the insane env**. Best-effort by design (fails through to original output).
- **`--device whisperx`** (#87) — parallel additive backend with VAD chunking + wav2vec2 alignment + pyannote diarization. Does **not** replace `--device insane`.
- **`--device sensevoice`** (#101) — FunASR/SenseVoiceSmall. Non-autoregressive, multilingual (`auto`/`zh`/`en`/`yue`/`ja`/`ko`/`nospeech`), built-in `fsmn-vad`, optional `cam++` diarization. Models pull from ModelScope by default; `--hub hf` for HuggingFace.

### Packaging

- **Read-only installs work now** (#100) — backend venvs + `static_ffmpeg` cache moved from `<site-packages>/transcribe_anything/venv/...` to `<user_cache_dir>/transcribe-anything/...`. Overridable via `TRANSCRIBE_ANYTHING_CACHE_DIR`. Unblocks Nix-store / OS-package / multi-user / baked-into-container installs.
- **Native Nix flake** (#104, originally #68 by @eeedean) — `nix run github:zackees/transcribe-anything` works; `nix shell` and `nix develop` give you the install or an editable dev environment. uv2nix-based, with `ffmpeg` and `uv` auto-wrapped on PATH. Pairs with the read-only-install support above.
- **Cloud / Serverless docs section** (#94, #98) — links @victorkjung's [RunPod Serverless fork](https://github.com/victorkjung/transcribe-anything/tree/runpod-integration/runpod) for users without a local GPU.

### Security & robustness

- **Mask `--hf-token` in insane backend** (#72) — stderr `Running:` banner and `OSError("Failed to execute ...")` traceback no longer leak the HuggingFace token. Subprocess still receives the real token. **Action recommended:** rotate any HF token that ran through 3.2.x on a serverless host with stderr/exception capture.
- **`audio.py` shell hardening** (#96) — `_convert_to_wav` now uses argv-list + `shell=False` + `check=True`, closing the shell-injection surface in the URL-download path and surfacing ffmpeg failures at the source instead of as confusing downstream symptoms.
- **Test mock fixes** (#102 / #106) — `static_ffmpeg.add_paths` mocks updated to accept the new `download_dir` kwarg introduced by #100.
- **srt_translation import fix** (#105) — `get_runtime_venv_dir` import added; was a silent runtime NameError since #100.

### Upgrade note

The venv-location move (#100) orphans existing 3.2 venv caches at the old path. **First run of each backend after upgrade re-downloads its dependencies** (~10 GB for `--device insane`). No data loss — just the one-time wheel fetch. Set `TRANSCRIBE_ANYTHING_CACHE_DIR=/somewhere/writable` to control the new location.

### Test plan

- [x] README renders cleanly (announcement section formatted, existing 3.2/3.1 sections preserved)
- [x] `pyproject.toml` version bumped to 4.0.0
- [x] All carve-out fixes merged (#105 srt_translation import, #106 insane-flash mocks)
- [x] Nix flake merged (#104) — uv2nix-based; tested aarch64-darwin per @eeedean
- [ ] CI: full suite on ubuntu / macos / windows
- [ ] Manual: `pip install -e .` reports 4.0.0 in `pip show transcribe-anything`
- [ ] Manual community validation: someone with a Nix host runs `nix build .#transcribe-anything`

### Full PR list since 3.2.10

#72, #87, #90, #91, #92, #94, #96, #97, #98, #99, #100, #101, #102, #104, #105, #106.