### PR TITLE
fix(srt_translation): import missing get_runtime_venv_dir

### DIFF
--- a/src/transcribe_anything/srt_translation.py
+++ b/src/transcribe_anything/srt_translation.py
@@ -8,6 +8,8 @@ from pathlib import Path
 
 from iso_env import IsoEnv, IsoEnvArgs, Requirements  # type: ignore
 
+from transcribe_anything.util import get_runtime_venv_dir
+
 # from isolated_environment import isolated_environment  # type: ignore
 
 


### PR DESCRIPTION
## Summary

Regression from #100. The runtime-cache-dir refactor switched `srt_translation.get_environment()` from `HERE / \"venv\" / \"srttranslator\"` to `get_runtime_venv_dir(\"srttranslator\")` but the helper import was never added. Python doesn't resolve names until call time, so the module imports cleanly and the bug went unnoticed at boot — but any call to `get_environment()` raises `NameError` at runtime.

Two-line fix:

\`\`\`python
+from transcribe_anything.util import get_runtime_venv_dir
\`\`\`

The mypy job on `main` (`test (3.11.8, ubuntu-latest)` — Lint workflow) has been flagging it as `Name \"get_runtime_venv_dir\" is not defined` since PR #100 landed; this clears that error.

## Test plan

- [x] `python -c \"from transcribe_anything.srt_translation import get_environment; get_environment()\"` succeeds (now returns the runtime-cache venv path).
- [ ] CI: lint passes (assuming no other unrelated lint failures).