### PR TITLE
refactor(server): migrate on_event shutdown to FastAPI lifespan

### DIFF
--- a/src/transcribe_anything/server_app.py
+++ b/src/transcribe_anything/server_app.py
@@ -26,6 +26,7 @@ Design constraints (issue #107):
 import json
 import shutil
 import tempfile
+from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Callable, Optional
 
@@ -77,10 +78,18 @@ def create_app(
         warmup = WarmupRunner(config, transcribe_fn or _default_transcribe_fn)
         warmup.start()
 
+    @asynccontextmanager
+    async def lifespan(_app: FastAPI):
+        try:
+            yield
+        finally:
+            store.stop()
+
     app = FastAPI(
         title="transcribe-anything daemon",
         version="1",
         description="Persistent FastAPI daemon for transcribe-anything (issue #107).",
+        lifespan=lifespan,
     )
 
     # Stash for tests / introspection.
@@ -230,10 +239,6 @@ def create_app(
         if not path.is_file():
             raise HTTPException(status_code=404, detail="artifact not found")
         return FileResponse(str(path), filename=filename)
-
-    @app.on_event("shutdown")
-    def _shutdown() -> None:
-        store.stop()
 
     return app
 


### PR DESCRIPTION
## Summary

One of the cheap follow-ups from #110 (daemon-mode v2 list).

FastAPI ≥ 0.110 deprecated `@app.on_event` in favor of the lifespan context manager. The daemon was pinned against `fastapi>=0.110.0,<1.0.0` and the test environment runs `fastapi==0.136`, so the deprecation warning was firing on every `create_app()` call — 26 warnings per test run.

This PR wraps `store.stop()` in an `@asynccontextmanager` passed via `FastAPI(lifespan=…)`. No behavior change: the worker still stops at app shutdown via the post-`yield` branch, and `try/finally` keeps the guarantee that `store.stop()` runs even if startup raises.

Before: 39 warnings / 41 passing. After: 1 warning / 41 passing (the remaining warning is unrelated — Starlette's TestClient flagging its httpx dependency).

## Test plan

- [x] `pytest tests/test_server_app.py tests/test_client.py` — 41/41 pass.
- [x] `mypy src tests --exclude src/transcribe_anything/venv` — clean.
- [x] `black --check src/transcribe_anything/server_app.py` — clean.

Tracks #110. Does **not** close #110 — that issue lists many sub-items; this PR only handles the "Migrate `@app.on_event` to lifespan API" checkbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)