### PR TITLE
feat(server): artifacts.zip endpoint + [server] pip extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -692,7 +692,8 @@ transcribe_remote(
 - **Non-goals for v1:** TLS termination (use nginx/caddy in front), multi-tenant identity, persistent job queue across restarts, multi-GPU scheduling.
 - **HF token redaction** — tokens supplied via `--hf-token` at daemon startup are stripped from every client-visible error and never appear in job-status responses (extends the redaction from PR #93 to the HTTP layer).
 - **Queue + concurrency** — the GPU is single-tenant per backend, so the daemon serializes work onto one worker. `--max-queue` (default 8) bounds the queue; overflow returns `429`.
-- **Endpoints** — `POST /v1/transcribe`, `GET /v1/jobs/{id}`, `GET /v1/jobs/{id}/artifacts/{filename}`, `DELETE /v1/jobs/{id}`, `GET /v1/capabilities`, `GET /healthz`, `GET /readyz`. Auth header is `Authorization: Bearer <token>` (or `X-Transcribe-Token: <token>`).
+- **Endpoints** — `POST /v1/transcribe`, `GET /v1/jobs/{id}`, `GET /v1/jobs/{id}/artifacts/{filename}`, `GET /v1/jobs/{id}/artifacts.zip` (all-artifacts bundle download), `DELETE /v1/jobs/{id}`, `GET /v1/capabilities`, `GET /healthz`, `GET /readyz`. Auth header is `Authorization: Bearer <token>` (or `X-Transcribe-Token: <token>`).
+- **In-process mode** — `pip install 'transcribe-anything[server]'` + `transcribe-anything serve --no-iso-env` skips the iso-env build and runs the daemon directly in your venv. Faster for dev / containers that already have FastAPI installed.
 
 ## Troubleshooting Common Issues
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,17 @@ dependencies = [
 version = "4.0.0"  # Update this manually or configure setuptools-scm for automatic versioning
 maintainers = [{ name = "Zachary Vorhies", email = "dont@email.me" }]
 
+[project.optional-dependencies]
+# `pip install transcribe-anything[server]` lets users run the daemon
+# directly in their main venv (transcribe-anything serve --no-iso-env)
+# instead of paying the iso-env build on first launch. Mirrors the
+# deps installed into the daemon iso-env in server_reqs.py.
+server = [
+    "fastapi>=0.110.0,<1.0.0",
+    "uvicorn>=0.27.0,<1.0.0",
+    "python-multipart>=0.0.9",
+]
+
 [project.urls]
 homepage = "https://github.com/zackees/transcribe-anything"
 

--- a/src/transcribe_anything/server_app.py
+++ b/src/transcribe_anything/server_app.py
@@ -23,15 +23,17 @@ Design constraints (issue #107):
   backend). Queue is bounded; overflow returns 429.
 """
 
+import io
 import json
 import shutil
 import tempfile
+import zipfile
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Callable, Optional
 
 from fastapi import Depends, FastAPI, Header, HTTPException, Request  # noqa: F401
-from fastapi.responses import FileResponse, JSONResponse, Response
+from fastapi.responses import FileResponse, JSONResponse, Response, StreamingResponse
 
 # Re-export pure-logic surface so test modules and external callers keep
 # importing from ``server_app`` after the file split.
@@ -239,6 +241,26 @@ def create_app(
         if not path.is_file():
             raise HTTPException(status_code=404, detail="artifact not found")
         return FileResponse(str(path), filename=filename)
+
+    @app.get("/v1/jobs/{job_id}/artifacts.zip")
+    def get_artifacts_zip(job_id: str, _: None = Depends(_auth_dep)) -> StreamingResponse:
+        job = store.get(job_id)
+        if job is None:
+            raise HTTPException(status_code=404, detail="unknown job")
+        artifact_dir = Path(job.artifact_dir)
+        files = sorted(p for p in artifact_dir.iterdir() if p.is_file()) if artifact_dir.is_dir() else []
+        if not files:
+            raise HTTPException(status_code=404, detail="no artifacts available for this job")
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+            for f in files:
+                zf.write(f, arcname=f.name)
+        buf.seek(0)
+        return StreamingResponse(
+            buf,
+            media_type="application/zip",
+            headers={"Content-Disposition": f'attachment; filename="job-{job_id}.zip"'},
+        )
 
     return app
 

--- a/tests/test_server_app.py
+++ b/tests/test_server_app.py
@@ -333,6 +333,31 @@ def test_delete_job_removes_artifacts(server_client) -> None:
     assert r2.status_code == 404
 
 
+def test_artifacts_zip_bundle_contains_all_outputs(server_client) -> None:
+    import io
+    import zipfile
+
+    client, _ = server_client
+    resp = client.post("/v1/transcribe", json={"url": "https://x"})
+    job_id = resp.json()["job_id"]
+    final = _wait_for_status(client, job_id)
+    assert final["status"] == "completed"
+
+    r = client.get(f"/v1/jobs/{job_id}/artifacts.zip")
+    assert r.status_code == 200
+    assert r.headers["content-type"].startswith("application/zip")
+    assert f'filename="job-{job_id}.zip"' in r.headers["content-disposition"]
+    with zipfile.ZipFile(io.BytesIO(r.content)) as zf:
+        names = set(zf.namelist())
+    assert {"out.txt", "out.srt", "out.vtt", "out.json"}.issubset(names)
+
+
+def test_artifacts_zip_returns_404_for_unknown_job(server_client) -> None:
+    client, _ = server_client
+    r = client.get("/v1/jobs/does-not-exist/artifacts.zip")
+    assert r.status_code == 404
+
+
 # --------------------- failure + redaction ---------------------
 
 


### PR DESCRIPTION
## Summary

Two more well-scoped items from #110:

* **`GET /v1/jobs/{job_id}/artifacts.zip`** — streams every artifact of a completed job as a single deflated zip. The endpoint was reserved in #107's design but not in v1. Saves one round trip per file for clients that want the whole bundle (the common case once `--align` produces JSON + the three subtitle formats).
* **`[server]` pip extras** — adds `pip install 'transcribe-anything[server]'`. Pairs with `transcribe-anything serve --no-iso-env` so users with FastAPI already in their venv can skip the iso-env build entirely. Versions mirror `server_reqs.py` so the iso-env and in-process paths stay interchangeable.

Endpoint table in the README + Operational notes updated accordingly.

## Test plan

- [x] `pytest tests/test_server_app.py tests/test_client.py` — 43/43 pass (2 new zip tests).
- [x] `mypy src tests --exclude src/transcribe_anything/venv` — clean.
- [x] `black --check` + isort — clean.
- [x] Rebased onto #111 (lifespan migration), so the deprecation warning stays at zero in this branch too.

Tracks #110. Does not close it — SSE progress, persistent queue, multi-GPU, Docker compose example, etc. still pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)