### PR TITLE
docs(server): docker compose + caddy/nginx reverse-proxy recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -687,9 +687,28 @@ transcribe_remote(
 )
 ```
 
+### Self-hosted with Docker + TLS reverse proxy
+
+`examples/serve-compose.yml` runs the daemon behind a Caddy reverse proxy with automatic Let's Encrypt TLS:
+
+```bash
+export TRANSCRIBE_ANYTHING_TOKEN=$(openssl rand -hex 32)
+export TRANSCRIBE_PUBLIC_HOST=transcribe.example.com
+docker compose -f examples/serve-compose.yml up -d
+
+# Then from any client
+transcribe-anything video.mp4 \
+  --remote "https://${TRANSCRIBE_PUBLIC_HOST}" \
+  --token  "${TRANSCRIBE_ANYTHING_TOKEN}"
+```
+
+The compose file isolates the daemon to an internal network and only publishes 80/443 from Caddy — the daemon's own `:8765` is never exposed to the host. Named volumes preserve the HuggingFace model cache and per-backend iso-envs across container rebuilds.
+
+If you prefer nginx, `examples/nginx.serve.conf` is a drop-in fragment with the right timeouts (4h `proxy_read_timeout`), `client_max_body_size 2g` to match `--max-upload-size`, and `proxy_buffering off` so the future SSE progress endpoint flushes events in real time.
+
 ### Operational notes
 
-- **Non-goals for v1:** TLS termination (use nginx/caddy in front), multi-tenant identity, persistent job queue across restarts, multi-GPU scheduling.
+- **Non-goals for v1:** multi-tenant identity, persistent job queue across restarts, multi-GPU scheduling. TLS termination is documented above via the reverse-proxy recipe.
 - **HF token redaction** — tokens supplied via `--hf-token` at daemon startup are stripped from every client-visible error and never appear in job-status responses (extends the redaction from PR #93 to the HTTP layer).
 - **Queue + concurrency** — the GPU is single-tenant per backend, so the daemon serializes work onto one worker. `--max-queue` (default 8) bounds the queue; overflow returns `429`.
 - **Endpoints** — `POST /v1/transcribe`, `GET /v1/jobs/{id}`, `GET /v1/jobs/{id}/artifacts/{filename}`, `DELETE /v1/jobs/{id}`, `GET /v1/capabilities`, `GET /healthz`, `GET /readyz`. Auth header is `Authorization: Bearer <token>` (or `X-Transcribe-Token: <token>`).

--- a/examples/Caddyfile
+++ b/examples/Caddyfile
@@ -1,0 +1,24 @@
+# Caddy config for the serve-compose.yml example.
+#
+# Uses the {$TRANSCRIBE_PUBLIC_HOST} env var so the same file works for
+# any hostname. Caddy automatically obtains and renews a Let's Encrypt
+# cert for that hostname.
+#
+# Set max body to match `--max-upload-size` on the daemon (default 2 GB).
+
+{$TRANSCRIBE_PUBLIC_HOST} {
+    reverse_proxy daemon:8765 {
+        # Long transcriptions can run for many minutes; bump per-request
+        # timeouts well above Caddy's default 60s.
+        transport http {
+            read_timeout 4h
+            write_timeout 4h
+        }
+    }
+
+    request_body {
+        max_size 2GB
+    }
+
+    encode gzip
+}

--- a/examples/nginx.serve.conf
+++ b/examples/nginx.serve.conf
@@ -1,0 +1,39 @@
+# nginx fragment for fronting `transcribe-anything serve` with TLS.
+#
+# Drop this into your nginx config (e.g. /etc/nginx/conf.d/transcribe.conf).
+# Assumes the daemon is reachable at 127.0.0.1:8765 from the nginx host
+# and that TLS certs already exist (e.g. via certbot's nginx plugin).
+
+upstream transcribe_anything_daemon {
+    server 127.0.0.1:8765;
+    keepalive 8;
+}
+
+server {
+    listen 443 ssl http2;
+    server_name transcribe.example.com;
+
+    # Match `--max-upload-size` on the daemon (default 2 GB).
+    client_max_body_size 2g;
+    # Transcription can run for many minutes.
+    proxy_read_timeout    4h;
+    proxy_send_timeout    4h;
+    proxy_connect_timeout 60s;
+
+    ssl_certificate     /etc/letsencrypt/live/transcribe.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/transcribe.example.com/privkey.pem;
+
+    location / {
+        proxy_pass http://transcribe_anything_daemon;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_http_version 1.1;
+        proxy_set_header   Connection      "";
+        # SSE-friendly buffering (kept off so progress events flush on time
+        # when the SSE endpoint lands in a future release).
+        proxy_buffering    off;
+    }
+}

--- a/examples/serve-compose.yml
+++ b/examples/serve-compose.yml
@@ -1,0 +1,80 @@
+# `transcribe-anything serve` deployment example.
+#
+# Drops the daemon behind a Caddy reverse proxy that terminates TLS via
+# Let's Encrypt and forwards to the internal :8765 port. The daemon
+# itself binds to 0.0.0.0 inside its container and requires the bearer
+# token defined via the TRANSCRIBE_ANYTHING_TOKEN env var. Caddy and
+# the daemon talk over an internal docker network — the daemon's port
+# is NOT published to the host.
+#
+# Usage:
+#   export TRANSCRIBE_ANYTHING_TOKEN=$(openssl rand -hex 32)
+#   export TRANSCRIBE_PUBLIC_HOST=transcribe.example.com
+#   docker compose -f examples/serve-compose.yml up -d
+#
+# Then from any client:
+#   transcribe-anything video.mp4 \
+#     --remote "https://${TRANSCRIBE_PUBLIC_HOST}" \
+#     --token  "${TRANSCRIBE_ANYTHING_TOKEN}"
+
+services:
+  daemon:
+    build: ..
+    command:
+      - transcribe-anything-serve
+      - --host=0.0.0.0
+      - --device=insane
+      - --model=large-v3
+      - --prefetch=eager
+      - --auth-token-env=TRANSCRIBE_ANYTHING_TOKEN
+    environment:
+      # Sourced from the shell that runs `docker compose up`.
+      - TRANSCRIBE_ANYTHING_TOKEN
+      # Mount a host directory (or named volume) here to keep the HF
+      # cache across container rebuilds — otherwise every `up` redownloads
+      # multi-GB of weights.
+      - HF_HOME=/cache/huggingface
+      - TRANSCRIBE_ANYTHING_CACHE_DIR=/cache/transcribe-anything
+    volumes:
+      - models:/cache/huggingface
+      - venvs:/cache/transcribe-anything
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - capabilities: [gpu]
+    # No `ports:` — the daemon is only reachable via the caddy service.
+    networks:
+      - internal
+    healthcheck:
+      # /healthz blocks until eager-prefetch warmup completes.
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8765/healthz"]
+      interval: 30s
+      timeout: 10s
+      retries: 30
+      start_period: 600s
+
+  caddy:
+    image: caddy:2-alpine
+    depends_on:
+      - daemon
+    ports:
+      - "80:80"
+      - "443:443"
+    environment:
+      - TRANSCRIBE_PUBLIC_HOST
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    networks:
+      - internal
+
+networks:
+  internal:
+
+volumes:
+  models:
+  venvs:
+  caddy_data:
+  caddy_config:


### PR DESCRIPTION
## Summary

Two more items from #110, both pure-docs/config (no Python):

* **TLS termination via reverse proxy.** Was a non-goal in v1 (#107); this PR makes it a one-command recipe by shipping a Caddyfile + an nginx fragment.
* **docker-compose example.** Walks through running the daemon on an internal network behind Caddy with automatic Let's Encrypt.

New files under \`examples/\`:

- **\`serve-compose.yml\`** — daemon + Caddy. Daemon binds 0.0.0.0 inside its container with bearer-token auth; only Caddy publishes 80/443. Named volumes cache HF weights + iso-envs so \`up\` doesn't redownload multi-GB of weights every time.
- **\`Caddyfile\`** — companion config. Auto Let's Encrypt cert via \$TRANSCRIBE_PUBLIC_HOST, 4h read/write timeout (transcriptions run long), \`request_body max_size 2GB\` to match \`--max-upload-size\`.
- **\`nginx.serve.conf\`** — drop-in fragment for the nginx variant. Same long timeouts, \`client_max_body_size 2g\`, \`proxy_buffering off\` so the future SSE endpoint flushes events in real time.

README: new "Self-hosted with Docker + TLS reverse proxy" subsection under Daemon Mode. Drops TLS from the v1 non-goals list (the recipe is now in-tree).

## Test plan

- [x] \`docker compose -f examples/serve-compose.yml config\` validates locally (compose file parses).
- [ ] Manual: full \`compose up\` against a real public hostname not exercised in CI (would need a real domain + DNS + working LE).

Tracks #110. Does not close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)