### PR TITLE
feat(client): add transcribe_remote_async() for asyncio callers

### DIFF
--- a/src/transcribe_anything/client.py
+++ b/src/transcribe_anything/client.py
@@ -12,6 +12,7 @@ deps so client mode works out of the box.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import sys
@@ -166,6 +167,104 @@ def transcribe_remote(
         return str(out_path)
     finally:
         client.close()
+
+
+async def transcribe_remote_async(
+    url_or_file: str,
+    *,
+    remote: str,
+    output_dir: Optional[str] = None,
+    token: Optional[str] = None,
+    model: Optional[str] = None,
+    task: Optional[str] = None,
+    language: Optional[str] = None,
+    initial_prompt: Optional[str] = None,
+    align: bool = False,
+    align_model: Optional[str] = None,
+    other_args: Optional[list[str]] = None,
+    embed: bool = False,
+    poll_interval_seconds: float = 1.0,
+    request_timeout_seconds: float = 30.0,
+    job_timeout_seconds: float = 60 * 60 * 4,
+) -> str:
+    """Async mirror of :func:`transcribe_remote`.
+
+    Same contract as the sync variant: submit a job, poll until terminal,
+    download artifacts into ``output_dir``, return the path. Uses
+    ``httpx.AsyncClient`` and ``asyncio.sleep`` so callers can drive
+    many remote transcriptions concurrently without burning a thread per
+    job.
+    """
+    base_url = _normalize_base_url(remote)
+    headers = _build_headers(token)
+    options = _collect_options(
+        model=model,
+        task=task,
+        language=language,
+        initial_prompt=initial_prompt,
+        align=align,
+        align_model=align_model,
+        other_args=other_args,
+        embed=embed,
+    )
+
+    is_url = url_or_file.startswith("http://") or url_or_file.startswith("https://") or url_or_file.startswith("ftp://")
+
+    async with httpx.AsyncClient(timeout=request_timeout_seconds, headers=headers) as client:
+        if is_url:
+            payload = {"url": url_or_file, **options}
+            resp = await client.post(f"{base_url}/v1/transcribe", json=payload)
+        else:
+            local = Path(url_or_file)
+            if not local.is_file():
+                raise RemoteTranscriberError(f"local file not found: {url_or_file}")
+            with local.open("rb") as fh:
+                files = {"file": (local.name, fh, "application/octet-stream")}
+                data = {"options": json.dumps(options)} if options else {}
+                resp = await client.post(f"{base_url}/v1/transcribe", files=files, data=data)
+        if resp.status_code >= 400:
+            raise RemoteTranscriberError(f"daemon at {base_url} rejected submission: {resp.status_code} {resp.text}")
+        body = resp.json()
+        job_id = body["job_id"]
+
+        deadline = time.time() + job_timeout_seconds
+        last_status = None
+        while True:
+            if time.time() > deadline:
+                raise RemoteTranscriberError(f"job {job_id} timed out after {job_timeout_seconds}s")
+            jr = await client.get(f"{base_url}/v1/jobs/{job_id}")
+            if jr.status_code >= 400:
+                raise RemoteTranscriberError(f"daemon returned {jr.status_code} fetching job status: {jr.text}")
+            job = jr.json()
+            status = job.get("status")
+            if status != last_status:
+                sys.stderr.write(f"remote job {job_id}: {status}\n")
+                last_status = status
+            if status == "completed":
+                break
+            if status == "failed":
+                raise RemoteTranscriberError(f"daemon job {job_id} failed: {job.get('error')}")
+            await asyncio.sleep(poll_interval_seconds)
+
+        if output_dir is None:
+            base = Path(url_or_file).name
+            stem = Path(base).stem if not is_url else (base or "remote")
+            output_dir = f"text_{stem or 'remote'}"
+        out_path = Path(output_dir).resolve()
+        out_path.mkdir(parents=True, exist_ok=True)
+
+        artifacts = job.get("artifacts") or []
+        if not artifacts:
+            raise RemoteTranscriberError(f"daemon job {job_id} reported no artifacts")
+        for name in artifacts:
+            dest = out_path / name
+            async with client.stream("GET", f"{base_url}/v1/jobs/{job_id}/artifacts/{name}") as r:
+                if r.status_code >= 400:
+                    raise RemoteTranscriberError(f"failed to download artifact {name}: {r.status_code} {await r.aread()!r}")
+                with dest.open("wb") as fh:
+                    async for chunk in r.aiter_bytes():
+                        fh.write(chunk)
+        return str(out_path)
 
 
 def resolve_remote_and_token(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -6,9 +6,11 @@ no subprocess. The actual transcribe() call is mocked.
 
 from __future__ import annotations
 
+import asyncio
 import json
 from pathlib import Path
 
+import httpx
 import pytest
 from starlette.testclient import TestClient
 
@@ -17,6 +19,7 @@ from transcribe_anything.client import (
     RemoteTranscriberError,
     resolve_remote_and_token,
     transcribe_remote,
+    transcribe_remote_async,
 )
 from transcribe_anything.server_app import create_app
 from transcribe_anything.server_config import ServerConfig
@@ -156,3 +159,80 @@ def test_resolve_remote_and_token_returns_none_when_unset(monkeypatch) -> None:
     remote, token = resolve_remote_and_token(remote_arg=None, token_arg=None)
     assert remote is None
     assert token is None
+
+
+# --------------------- async client ---------------------
+
+
+@pytest.fixture
+def asgi_async_client_factory(asgi_app, monkeypatch):
+    """Monkeypatch ``httpx.AsyncClient`` used by ``transcribe_remote_async``.
+
+    Unlike sync httpx, the async client *does* accept ``ASGITransport``
+    directly, so we just inject one pointing at the in-process FastAPI app.
+    """
+    transport = httpx.ASGITransport(app=asgi_app)
+    real_async_client = httpx.AsyncClient
+
+    def factory(*args, **kwargs):
+        kwargs.setdefault("transport", transport)
+        kwargs.setdefault("base_url", "http://testserver")
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(client_mod.httpx, "AsyncClient", factory)
+    return factory
+
+
+def test_transcribe_remote_async_url_path(asgi_async_client_factory, tmp_path) -> None:
+    out_dir = tmp_path / "out"
+    result = asyncio.run(
+        transcribe_remote_async(
+            url_or_file="https://example.com/foo.mp3",
+            remote="http://testserver",
+            output_dir=str(out_dir),
+            poll_interval_seconds=0.01,
+        )
+    )
+    assert Path(result).resolve() == out_dir.resolve()
+    assert (out_dir / "out.txt").is_file()
+    assert (out_dir / "out.srt").is_file()
+
+
+def test_transcribe_remote_async_file_upload(asgi_async_client_factory, tmp_path) -> None:
+    src = tmp_path / "audio.wav"
+    src.write_bytes(b"RIFF\x00\x00\x00\x00WAVEfmt ")
+    out_dir = tmp_path / "out"
+    result = asyncio.run(
+        transcribe_remote_async(
+            url_or_file=str(src),
+            remote="http://testserver",
+            output_dir=str(out_dir),
+            poll_interval_seconds=0.01,
+        )
+    )
+    assert Path(result).resolve() == out_dir.resolve()
+    assert (out_dir / "out.txt").read_text(encoding="utf-8") == "hello"
+
+
+def test_transcribe_remote_async_rejects_missing_file(asgi_async_client_factory, tmp_path) -> None:
+    with pytest.raises(RemoteTranscriberError):
+        asyncio.run(
+            transcribe_remote_async(
+                url_or_file=str(tmp_path / "nope.wav"),
+                remote="http://testserver",
+                output_dir=str(tmp_path / "out"),
+            )
+        )
+
+
+def test_transcribe_remote_async_surfaces_daemon_4xx(asgi_async_client_factory, tmp_path) -> None:
+    with pytest.raises(RemoteTranscriberError) as exc:
+        asyncio.run(
+            transcribe_remote_async(
+                url_or_file="https://example.com/x.mp3",
+                remote="http://testserver",
+                output_dir=str(tmp_path / "out"),
+                model="large-v3",  # locked field, daemon default is "tiny"
+            )
+        )
+    assert "400" in str(exc.value)


### PR DESCRIPTION
## Summary

Adds an `async` mirror of the existing `transcribe_remote()` to `transcribe_anything.client`. Same args, same return value, same error class — just driven by `httpx.AsyncClient` + `asyncio.sleep` so callers in asyncio code can drive N remote transcriptions concurrently without burning a thread per job.

Useful for: in-process async services that already use FastAPI / aiohttp / Trio, batch tooling that wants to parallelize N file submissions to one daemon, the future SSE-streaming client path (#114) which will be async-native.

## Test plan

- [x] `pytest tests/test_client.py tests/test_server_app.py` — 45/45 pass (4 new async tests).
- [x] `mypy src tests --exclude src/transcribe_anything/venv` — clean.
- [x] `black --check` + isort — clean.

Implementation note: `httpx.AsyncClient` *does* accept `ASGITransport` directly (unlike sync `httpx.Client` — that's why the sync tests needed the Starlette TestClient shim). The async fixture is simpler as a result.

Addresses one bullet of #110 (the async-client item). Does not close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)