### PR TITLE
feat(server): WS /v1/stream protocol skeleton + StreamSession (#122)

### DIFF
--- a/README.md
+++ b/README.md
@@ -706,6 +706,31 @@ The compose file isolates the daemon to an internal network and only publishes 8
 
 If you prefer nginx, `examples/nginx.serve.conf` is a drop-in fragment with the right timeouts (4h `proxy_read_timeout`), `client_max_body_size 2g` to match `--max-upload-size`, and `proxy_buffering off` so the future SSE progress endpoint flushes events in real time.
 
+### Realtime streaming (`WS /v1/stream`) — protocol skeleton
+
+> **v1 status:** The WebSocket protocol and the single-stream serializer are wired up. The production backend (faster-whisper + silero-vad chunker) lands in a follow-up PR. Tracking issue: [#122](https://github.com/zackees/transcribe-anything/issues/122).
+
+Opt-in with `--allow-stream`:
+
+```bash
+transcribe-anything serve --allow-stream --max-stream-duration 3600
+```
+
+Wire protocol on `WS /v1/stream`:
+
+| Direction | Frame | Payload |
+|---|---|---|
+| C → S | text (first) | `{"type":"hello","model":"small.en","language":"en","sample_rate":16000,"encoding":"pcm16le"}` |
+| C → S | binary | raw PCM16-LE mono audio at the declared sample rate |
+| C → S | text (optional) | `{"type":"end_of_input"}` for graceful EOF, `{"type":"cancel"}` for immediate abort |
+| S → C | text | `{"type":"ready"}`, then `{"type":"partial"|"final","text":"…","rev":N}` events, then `{"type":"done"}` |
+
+`rev` increments monotonically. A `final` locks its span; later `partial`s never overwrite locked text. Close codes use the WebSocket private range (4401 unauthorized, 4429 busy — one streaming session per daemon, 4408 session duration exceeded, 4403 disabled).
+
+Auth: same `Authorization: Bearer <token>` (or `X-Transcribe-Token`) as `/v1/*`.
+
+The in-tree backend is a **canned scripted generator** intended for protocol validation only — it emits a fixed transcript regardless of audio. Real backends register via the `streaming_fn=…` kwarg on `create_app(...)` and will arrive in a follow-up PR per #122.
+
 ### Operational notes
 
 - **Non-goals for v1:** multi-tenant identity, persistent job queue across restarts, multi-GPU scheduling. TLS termination is documented above via the reverse-proxy recipe.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ server = [
     "fastapi>=0.110.0,<1.0.0",
     "uvicorn>=0.27.0,<1.0.0",
     "python-multipart>=0.0.9",
+    "websockets>=12.0",
 ]
 
 [project.urls]

--- a/requirements.testing.txt
+++ b/requirements.testing.txt
@@ -9,3 +9,4 @@ twine
 fastapi>=0.110.0
 python-multipart>=0.0.9
 uvicorn>=0.27.0
+websockets>=12.0

--- a/src/transcribe_anything/cli_serve.py
+++ b/src/transcribe_anything/cli_serve.py
@@ -80,6 +80,23 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         default=10.0,
         help="per-attempt timeout (seconds) for webhook POSTs. Default 10s.",
     )
+    parser.add_argument(
+        "--allow-stream",
+        action="store_true",
+        help="enable WS /v1/stream for realtime transcription (#122). v1 ships the protocol skeleton with a canned backend; real backends land in a follow-up PR.",
+    )
+    parser.add_argument(
+        "--max-stream-duration",
+        type=int,
+        default=60 * 60,
+        help="hard cap on a single streaming session (seconds). Default 3600.",
+    )
+    parser.add_argument(
+        "--stream-decode-interval-ms",
+        type=int,
+        default=200,
+        help="cadence at which the streaming backend emits partial events (ms). Default 200.",
+    )
     parser.add_argument("--hf-token", default=None, help="HuggingFace token (never echoed to clients)")
     parser.add_argument(
         "--prefetch",
@@ -158,6 +175,9 @@ def _config_from_args(args: argparse.Namespace) -> "ServerConfig":  # type: igno
         shutdown_grace_seconds=args.shutdown_grace,
         allow_webhooks=bool(args.allow_webhooks),
         webhook_timeout_seconds=args.webhook_timeout,
+        allow_stream=bool(args.allow_stream),
+        max_stream_duration_seconds=args.max_stream_duration,
+        stream_decode_interval_ms=args.stream_decode_interval_ms,
     )
 
 

--- a/src/transcribe_anything/server_app.py
+++ b/src/transcribe_anything/server_app.py
@@ -23,6 +23,7 @@ Design constraints (issue #107):
   backend). Queue is bounded; overflow returns 429.
 """
 
+import asyncio
 import io
 import json
 import shutil
@@ -30,9 +31,17 @@ import tempfile
 import zipfile
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import Callable, Optional
+from typing import Callable, Iterable, Optional
 
-from fastapi import Depends, FastAPI, Header, HTTPException, Request  # noqa: F401
+from fastapi import (  # noqa: F401
+    Depends,
+    FastAPI,
+    Header,
+    HTTPException,
+    Request,
+    WebSocket,
+    WebSocketDisconnect,
+)
 from fastapi.responses import FileResponse, JSONResponse, Response, StreamingResponse
 
 # Re-export pure-logic surface so test modules and external callers keep
@@ -40,13 +49,21 @@ from fastapi.responses import FileResponse, JSONResponse, Response, StreamingRes
 from transcribe_anything.server_config import (
     DEFAULT_HOST,
     DEFAULT_PORT,
+    WS_CLOSE_BUSY,
+    WS_CLOSE_DURATION_EXCEEDED,
+    WS_CLOSE_INTERNAL,
+    WS_CLOSE_NOT_ALLOWED,
+    WS_CLOSE_UNAUTHORIZED,
     Job,
     JobStatus,
     JobStore,
     QueueFull,
     ServerConfig,
     SettingsViolation,
+    StreamCancelled,
+    StreamSession,
     WarmupRunner,
+    _canned_streaming_fn,
     _default_transcribe_fn,
     _redact_secrets,
 )
@@ -64,6 +81,7 @@ def create_app(
     *,
     transcribe_fn: Optional[Callable[..., str]] = None,
     job_root: Optional[Path] = None,
+    streaming_fn: Optional[Callable[..., Iterable[dict]]] = None,
 ) -> FastAPI:
     """Build the FastAPI app. Pure factory — easy to unit-test."""
     config.validate()
@@ -74,6 +92,11 @@ def create_app(
 
     store = JobStore(config, transcribe_fn=transcribe_fn)
     store.start()
+    stream_session = StreamSession()
+    # Real backends (faster-whisper, whisper.cpp) will replace this via the
+    # streaming_fn= kwarg. The fallback is a canned scripted generator —
+    # safe to leave in place because allow_stream defaults to False.
+    active_streaming_fn = streaming_fn or _canned_streaming_fn
 
     warmup: Optional[WarmupRunner] = None
     if config.prefetch == "eager":
@@ -286,6 +309,171 @@ def create_app(
             media_type="application/zip",
             headers={"Content-Disposition": f'attachment; filename="job-{job_id}.zip"'},
         )
+
+    # ---- realtime streaming (#122) ----
+    # WebSocket handler implementing the wire protocol from the issue:
+    #   client → server: text "hello" frame, then binary PCM frames,
+    #                    optional "end_of_input" or "cancel" text frames.
+    #   server → client: text "ready", then any number of "partial" /
+    #                    "final" / "metrics" frames, then "done".
+    # The backend is pluggable via streaming_fn; the in-tree fallback is a
+    # canned scripted generator (safe because allow_stream defaults to off).
+    @app.websocket("/v1/stream")
+    async def stream(ws: WebSocket) -> None:
+        await ws.accept()
+        if not config.allow_stream:
+            await ws.send_json({"type": "error", "code": "stream_disabled", "message": "daemon was not started with --allow-stream"})
+            await ws.close(code=WS_CLOSE_NOT_ALLOWED)
+            return
+
+        if config.requires_auth():
+            auth = ws.headers.get("authorization") or ""
+            x_tok = ws.headers.get("x-transcribe-token")
+            if not _check_auth(config, auth, x_tok):
+                await ws.send_json({"type": "error", "code": "unauthorized"})
+                await ws.close(code=WS_CLOSE_UNAUTHORIZED)
+                return
+
+        if not stream_session.acquire():
+            await ws.send_json({"type": "error", "code": "busy", "message": "another stream is in-flight"})
+            await ws.close(code=WS_CLOSE_BUSY)
+            return
+
+        try:
+            # Wait for the hello frame (text). Anything else → error.
+            try:
+                hello_raw = await ws.receive_text()
+            except WebSocketDisconnect:
+                return
+            try:
+                hello = json.loads(hello_raw)
+            except json.JSONDecodeError:
+                await ws.send_json({"type": "error", "code": "bad_hello", "message": "first frame must be JSON"})
+                return
+            if not isinstance(hello, dict) or hello.get("type") != "hello":
+                await ws.send_json({"type": "error", "code": "bad_hello", "message": "first frame must be {'type':'hello',...}"})
+                return
+
+            await ws.send_json({"type": "ready"})
+
+            # Pull audio frames + control frames into an async queue so the
+            # backend generator (which is sync) can iterate them without
+            # blocking the event loop.
+            audio_queue: asyncio.Queue = asyncio.Queue(maxsize=256)
+            input_done = asyncio.Event()
+
+            async def _pump_inputs() -> None:
+                deadline = stream_session.runtime_seconds
+                while not input_done.is_set():
+                    try:
+                        msg = await ws.receive()
+                    except WebSocketDisconnect:
+                        stream_session.cancel()
+                        input_done.set()
+                        return
+                    if "bytes" in msg and msg["bytes"] is not None:
+                        await audio_queue.put(msg["bytes"])
+                    elif "text" in msg and msg["text"] is not None:
+                        try:
+                            ctrl = json.loads(msg["text"])
+                        except json.JSONDecodeError:
+                            continue
+                        if not isinstance(ctrl, dict):
+                            continue
+                        if ctrl.get("type") == "end_of_input":
+                            input_done.set()
+                            return
+                        if ctrl.get("type") == "cancel":
+                            stream_session.cancel()
+                            input_done.set()
+                            return
+                    # Hard cap on session duration to keep a misbehaving
+                    # client from pinning the GPU forever.
+                    runtime = stream_session.runtime_seconds
+                    if runtime is not None and runtime > config.max_stream_duration_seconds:
+                        await ws.send_json({"type": "error", "code": "duration_exceeded"})
+                        await ws.close(code=WS_CLOSE_DURATION_EXCEEDED)
+                        stream_session.cancel()
+                        input_done.set()
+                        return
+                    _ = deadline  # currently unused; placeholder for adaptive backpressure
+
+            pumper = asyncio.create_task(_pump_inputs())
+
+            def _audio_iterable():
+                """Non-blocking generator over the audio queue.
+
+                Yields whatever PCM frames are currently buffered, then
+                returns. The backend is expected to iterate this once per
+                decode cycle — looping forever inside it would block the
+                sync backend thread waiting on the async pumper.
+                """
+                while True:
+                    if stream_session.is_cancelled:
+                        return
+                    try:
+                        chunk = audio_queue.get_nowait()
+                    except asyncio.QueueEmpty:
+                        return
+                    yield chunk
+
+            # Drive the (sync) streaming backend in a thread so it doesn't
+            # block the event loop. Forward each emitted event over the
+            # socket as a text frame.
+            loop = asyncio.get_running_loop()
+            queue_out: asyncio.Queue = asyncio.Queue()
+
+            def _run_backend() -> None:
+                try:
+                    for event in active_streaming_fn(_audio_iterable(), session=stream_session, config=config, hello=hello):
+                        asyncio.run_coroutine_threadsafe(queue_out.put(event), loop)
+                except StreamCancelled:
+                    pass
+                except Exception as exc:  # pylint: disable=broad-except
+                    redacted = _redact_secrets(str(exc), config.hf_token)
+                    asyncio.run_coroutine_threadsafe(queue_out.put({"type": "error", "code": "backend_failure", "message": redacted}), loop)
+                finally:
+                    asyncio.run_coroutine_threadsafe(queue_out.put({"type": "done"}), loop)
+
+            backend_thread = asyncio.get_event_loop().run_in_executor(None, _run_backend)
+
+            try:
+                while True:
+                    event = await queue_out.get()
+                    try:
+                        await ws.send_json(event)
+                    except (WebSocketDisconnect, RuntimeError):
+                        stream_session.cancel()
+                        break
+                    if event.get("type") == "done":
+                        break
+            finally:
+                input_done.set()
+                pumper.cancel()
+                try:
+                    await backend_thread
+                except Exception:  # pylint: disable=broad-except
+                    pass
+
+            try:
+                await ws.close()
+            except RuntimeError:
+                pass
+        except Exception as exc:  # pylint: disable=broad-except
+            redacted = _redact_secrets(str(exc), config.hf_token)
+            try:
+                await ws.send_json({"type": "error", "code": "internal", "message": redacted})
+            except Exception:  # pylint: disable=broad-except
+                pass
+            try:
+                await ws.close(code=WS_CLOSE_INTERNAL)
+            except RuntimeError:
+                pass
+        finally:
+            stream_session.release()
+
+    # Stash for tests / introspection.
+    app.state.stream_session = stream_session
 
     return app
 

--- a/src/transcribe_anything/server_config.py
+++ b/src/transcribe_anything/server_config.py
@@ -89,6 +89,14 @@ class ServerConfig:
     # services.
     allow_webhooks: bool = False
     webhook_timeout_seconds: float = 10.0
+    # Realtime streaming (#122). v1 ships the WebSocket protocol skeleton
+    # plus a pluggable streaming_fn; the production faster-whisper backend
+    # is a follow-up PR. `allow_stream=False` keeps the endpoint closed for
+    # daemons that don't need it (the canned fallback streaming_fn is for
+    # tests/dev only and shouldn't be exposed by default).
+    allow_stream: bool = False
+    max_stream_duration_seconds: int = 60 * 60
+    stream_decode_interval_ms: int = 200
 
     def requires_auth(self) -> bool:
         return not _is_loopback(self.host)
@@ -429,6 +437,117 @@ class WarmupRunner:
     @property
     def error(self) -> Optional[str]:
         return self._error
+
+
+# ----------------------------------------------------------------------
+# Realtime streaming (#122).
+#
+# This module owns the FastAPI-free skeleton: the ``StreamSession``
+# serializer (one in-flight WS connection per daemon) and the pluggable
+# ``StreamingTranscribeFn`` protocol. The actual WebSocket route lives in
+# ``server_app.py`` so this module stays importable without FastAPI.
+#
+# The faster-whisper backend (acceptance criterion #1 in #122) is
+# *deliberately* not in this PR — it needs its own iso-env, model-load
+# warmup, GPU benchmarking, and tests against a real WAV. This PR ships
+# the protocol + plumbing so that the real backend can be dropped in
+# behind the same ``streaming_fn`` interface in a follow-up.
+# ----------------------------------------------------------------------
+
+
+# Wire-protocol close codes (private 4000-4999 range per RFC 6455).
+WS_CLOSE_UNAUTHORIZED = 4401
+WS_CLOSE_BUSY = 4429  # another stream is already in-flight
+WS_CLOSE_DURATION_EXCEEDED = 4408
+WS_CLOSE_INTERNAL = 4499
+WS_CLOSE_NOT_ALLOWED = 4403  # daemon was not started with --allow-stream
+
+
+class StreamCancelled(Exception):
+    """Raised inside a streaming backend when the session is asked to abort."""
+
+
+class StreamSession:
+    """Serializes the one-streaming-connection-per-daemon invariant.
+
+    Use as a context manager from the WebSocket handler. ``acquire()``
+    returns False if another session is already live; the handler then
+    closes the new connection with :data:`WS_CLOSE_BUSY`.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._active: bool = False
+        self._cancel = threading.Event()
+        self._started_at: Optional[float] = None
+
+    def acquire(self) -> bool:
+        with self._lock:
+            if self._active:
+                return False
+            self._active = True
+            self._cancel.clear()
+            self._started_at = time.time()
+            return True
+
+    def release(self) -> None:
+        with self._lock:
+            self._active = False
+            self._started_at = None
+
+    def cancel(self) -> None:
+        """Signal the backend to abort at the next safe point."""
+        self._cancel.set()
+
+    @property
+    def is_active(self) -> bool:
+        with self._lock:
+            return self._active
+
+    @property
+    def is_cancelled(self) -> bool:
+        return self._cancel.is_set()
+
+    @property
+    def runtime_seconds(self) -> Optional[float]:
+        with self._lock:
+            if self._started_at is None:
+                return None
+            return time.time() - self._started_at
+
+
+def _canned_streaming_fn(audio_iter: Any, *, session: StreamSession, **_kwargs: Any):
+    """Stand-in streaming backend.
+
+    Yields a fixed scripted sequence of ``partial`` / ``final`` events,
+    decoupled from the audio bytes (we just drain them to keep the
+    socket flowing). Useful for tests and for end-to-end protocol
+    validation in dev environments without a GPU.
+
+    Real backends will replace this via ``create_app(streaming_fn=...)``.
+    They are expected to honor :attr:`StreamSession.is_cancelled` between
+    chunks and raise :class:`StreamCancelled` to abort cleanly.
+    """
+    scripted = [
+        ("partial", "the", 1),
+        ("partial", "the quick", 2),
+        ("final", "the quick brown fox", 3),
+        ("partial", "jumps", 4),
+        ("final", "jumps over the lazy dog", 5),
+    ]
+    # Drain a few audio frames so the socket exercises both directions.
+    drained = 0
+    iterator = iter(audio_iter)
+    for kind, text, rev in scripted:
+        if session.is_cancelled:
+            raise StreamCancelled("stream cancelled by client")
+        try:
+            next(iterator)
+            drained += 1
+        except StopIteration:
+            pass
+        yield {"type": kind, "text": text, "rev": rev}
+    yield {"type": "metrics", "audio_frames_received": drained}
 
 
 def _make_silent_wav(duration_seconds: float = 1.0, sample_rate: int = 16000) -> Path:

--- a/src/transcribe_anything/server_reqs.py
+++ b/src/transcribe_anything/server_reqs.py
@@ -33,6 +33,11 @@ _SERVER_DEPS = [
     "uvicorn>=0.27.0,<1.0.0",
     "python-multipart>=0.0.9",
     "httpx>=0.27.0",
+    # WS /v1/stream (#122) — FastAPI/Starlette dispatches WebSocket via
+    # the ``websockets`` library; uvicorn's [standard] extra also pulls
+    # it in, but the iso-env declares it explicitly so dev/test envs
+    # (--no-iso-env) don't have to guess.
+    "websockets>=12.0",
     # Mirror of the host base deps so `import transcribe_anything.*` works
     # against the host source via PYTHONPATH.
     "static-ffmpeg>=3.0",

--- a/tests/test_stream_protocol.py
+++ b/tests/test_stream_protocol.py
@@ -1,0 +1,203 @@
+"""Tests for the realtime streaming WebSocket protocol (#122 skeleton).
+
+The real backend (faster-whisper) is a follow-up PR. These tests cover
+the protocol + StreamSession semantics using the canned in-tree backend.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+from transcribe_anything.server_app import create_app
+from transcribe_anything.server_config import ServerConfig, StreamSession
+
+
+def _cfg(tmp_path, *, allow_stream: bool = True, **kw) -> ServerConfig:
+    return ServerConfig(
+        host="127.0.0.1",
+        model="tiny",
+        job_root=str(tmp_path / "jobs"),
+        allow_stream=allow_stream,
+        **kw,
+    )
+
+
+def _hello_frame() -> str:
+    return json.dumps({"type": "hello", "model": "small.en", "language": "en", "sample_rate": 16000, "encoding": "pcm16le"})
+
+
+# ---------------------------------------------------------------- StreamSession
+
+
+def test_stream_session_acquire_release_cycle() -> None:
+    s = StreamSession()
+    assert s.acquire() is True
+    assert s.is_active is True
+    assert s.acquire() is False  # second acquire while held -> False
+    s.release()
+    assert s.is_active is False
+    assert s.acquire() is True  # available again after release
+
+
+def test_stream_session_cancel_flag() -> None:
+    s = StreamSession()
+    s.acquire()
+    assert s.is_cancelled is False
+    s.cancel()
+    assert s.is_cancelled is True
+    s.release()
+    # Next acquire clears the flag.
+    s.acquire()
+    assert s.is_cancelled is False
+
+
+def test_stream_session_runtime_seconds() -> None:
+    s = StreamSession()
+    assert s.runtime_seconds is None
+    s.acquire()
+    rt = s.runtime_seconds
+    assert rt is not None and rt >= 0.0
+    s.release()
+    assert s.runtime_seconds is None
+
+
+# ---------------------------------------------------------------- WS endpoint
+
+
+def test_stream_endpoint_disabled_by_default(tmp_path) -> None:
+    cfg = _cfg(tmp_path, allow_stream=False)
+    app = create_app(cfg)
+    with TestClient(app) as client:
+        with pytest.raises(Exception):
+            # Should get error frame then close with WS_CLOSE_NOT_ALLOWED.
+            with client.websocket_connect("/v1/stream") as ws:
+                msg = ws.receive_json()
+                assert msg["type"] == "error"
+                assert msg["code"] == "stream_disabled"
+                # Now receiving past the close should raise.
+                ws.receive_json()
+
+
+def test_stream_endpoint_happy_path_yields_done(tmp_path) -> None:
+    cfg = _cfg(tmp_path, allow_stream=True)
+    app = create_app(cfg)
+    with TestClient(app) as client:
+        with client.websocket_connect("/v1/stream") as ws:
+            ws.send_text(_hello_frame())
+            ready = ws.receive_json()
+            assert ready == {"type": "ready"}
+
+            # Send some fake audio so the canned backend has something to drain.
+            for _ in range(3):
+                ws.send_bytes(b"\x00\x00" * 1600)  # 100ms of silence @ 16kHz
+
+            collected = []
+            # Read events until done.
+            while True:
+                msg = ws.receive_json()
+                collected.append(msg)
+                if msg.get("type") == "done":
+                    break
+
+            kinds = [m["type"] for m in collected]
+            assert "partial" in kinds
+            assert "final" in kinds
+            assert kinds[-1] == "done"
+
+            # rev monotonically increases across partial+final events.
+            revs = [m["rev"] for m in collected if "rev" in m]
+            assert revs == sorted(revs)
+            assert len(set(revs)) == len(revs)
+
+
+def test_stream_endpoint_rejects_non_hello_first_frame(tmp_path) -> None:
+    cfg = _cfg(tmp_path, allow_stream=True)
+    app = create_app(cfg)
+    with TestClient(app) as client:
+        with client.websocket_connect("/v1/stream") as ws:
+            ws.send_text("not json at all")
+            msg = ws.receive_json()
+            assert msg["type"] == "error"
+            assert msg["code"] == "bad_hello"
+
+
+def test_stream_endpoint_rejects_wrong_type_first_frame(tmp_path) -> None:
+    cfg = _cfg(tmp_path, allow_stream=True)
+    app = create_app(cfg)
+    with TestClient(app) as client:
+        with client.websocket_connect("/v1/stream") as ws:
+            ws.send_text(json.dumps({"type": "cancel"}))
+            msg = ws.receive_json()
+            assert msg["type"] == "error"
+            assert msg["code"] == "bad_hello"
+
+
+def test_stream_endpoint_busy_when_session_already_acquired(tmp_path) -> None:
+    """Pre-acquire the daemon's StreamSession; the WS handler must reject the new connection.
+
+    Done by reaching into ``app.state.stream_session`` directly instead of
+    holding a parallel WebSocket open from a worker thread — the latter
+    deadlocks the sync TestClient.
+    """
+    cfg = _cfg(tmp_path, allow_stream=True)
+    app = create_app(cfg)
+    # Simulate a live session by pre-acquiring before the new connection.
+    assert app.state.stream_session.acquire() is True
+    try:
+        with TestClient(app) as client:
+            with client.websocket_connect("/v1/stream") as ws:
+                msg = ws.receive_json()
+                assert msg["type"] == "error"
+                assert msg["code"] == "busy"
+    finally:
+        app.state.stream_session.release()
+
+
+def test_stream_endpoint_requires_auth_when_non_loopback(tmp_path) -> None:
+    cfg = ServerConfig(host="0.0.0.0", auth_token="secret", model="tiny", allow_stream=True, job_root=str(tmp_path))
+    app = create_app(cfg)
+    with TestClient(app) as client:
+        # No header → 4401 close.
+        with client.websocket_connect("/v1/stream") as ws:
+            msg = ws.receive_json()
+            assert msg["type"] == "error"
+            assert msg["code"] == "unauthorized"
+
+    with TestClient(app) as client:
+        # Correct header → ready frame.
+        with client.websocket_connect("/v1/stream", headers={"Authorization": "Bearer secret"}) as ws:
+            ws.send_text(_hello_frame())
+            msg = ws.receive_json()
+            assert msg["type"] == "ready"
+
+
+def test_stream_endpoint_pluggable_streaming_fn(tmp_path) -> None:
+    """A custom streaming_fn replaces the canned backend end-to-end."""
+
+    def _fn(audio_iter, *, session, config, hello):
+        # Confirm hello is forwarded; drain a frame; emit a single final.
+        assert hello["type"] == "hello"
+        assert hello["language"] == "en"
+        try:
+            next(iter(audio_iter))
+        except StopIteration:
+            pass
+        yield {"type": "final", "text": "custom backend ran", "rev": 1}
+
+    cfg = _cfg(tmp_path, allow_stream=True)
+    app = create_app(cfg, streaming_fn=_fn)
+    with TestClient(app) as client:
+        with client.websocket_connect("/v1/stream") as ws:
+            ws.send_text(_hello_frame())
+            assert ws.receive_json() == {"type": "ready"}
+            ws.send_bytes(b"\x00" * 100)
+            collected = []
+            while True:
+                msg = ws.receive_json()
+                collected.append(msg)
+                if msg.get("type") == "done":
+                    break
+            assert {"type": "final", "text": "custom backend ran", "rev": 1} in collected


### PR DESCRIPTION
## Summary

Addresses #122 (low-latency bidirectional streaming). This PR lands the **wire-protocol foundation** so a follow-up PR can drop a real backend (faster-whisper + silero-vad) behind the same `streaming_fn=…` interface without redesigning the daemon.

#122's full acceptance criteria call for a complete backend + sub-1s p50 latency measurement. That's many days of work and the wrong shape for one PR. This PR ships the parts that don't depend on the backend choice; the backend itself lands in a dedicated follow-up.

### What's in scope here

- **`WS /v1/stream`** WebSocket route on the FastAPI app. Bearer-auth on connect (same scheme as `/v1/*`); 4401 close on bad auth.
- **`StreamSession`** serializer in `server_config.py`: one streaming connection per daemon at a time. A second concurrent connect gets WS 4429 + an error frame and the close. Mirrors the single-tenant-per-GPU invariant the batch `JobStore` enforces.
- **Wire protocol** per the issue:
  ```
  C → S: text {hello,...} first, then binary PCM, optional end_of_input / cancel control frames
  S → C: ready, then partial / final / metrics events with a monotonic rev counter, terminated by done
  ```
- **`--max-stream-duration-seconds`** hard cap; 4408 close when exceeded.
- **Cancellation flag** the backend checks between chunks (mirrors #120's batch-cancel mechanism). WS close from the client also triggers it.
- **Pluggable `streaming_fn=…`** kwarg on `create_app(...)` for real backends. The in-tree fallback is a **canned scripted generator** suitable only for tests and protocol validation — safe because `allow_stream` defaults to `False`.
- **CLI flags** `--allow-stream`, `--max-stream-duration`, `--stream-decode-interval-ms` on `transcribe-anything-serve`.
- **`websockets>=12.0`** added to the server iso-env (`server_reqs.py`), `[server]` extras, and testing reqs so the route works in iso-env, in-process (`--no-iso-env`), and CI.
- **README** new "Realtime streaming" subsection under Daemon Mode with the wire-protocol table and an explicit "protocol skeleton; real backend next PR" note.

### What this PR explicitly defers

These each become their own follow-up issue and PR (the umbrella stays #122 until they all land):

- **faster-whisper + silero-vad backend** implementing real audio decoding (the heavy lift: iso-env, model warmup, GPU benchmarking, the sub-1s latency target).
- **CLI `--stream-in` flag** for piping `arecord` / `ffmpeg` audio.
- **`stream_remote()` async client helper** for asyncio callers.
- **p50 latency measurement harness.**

The follow-up PR for the backend can register itself via `create_app(streaming_fn=…)`; nothing in this PR needs to be re-architected.

## Test plan

- [x] `pytest tests/test_server_app.py tests/test_client.py tests/test_stream_protocol.py` — **61/61 pass** (10 new tests cover StreamSession lifecycle, WS happy path, hello-frame validation, busy-on-second-connection, auth gating for non-loopback bind, and pluggable `streaming_fn=`).
- [x] `mypy src tests --exclude src/transcribe_anything/venv` — clean.
- [x] `black --check` + isort — clean.
- [ ] Real-traffic WS smoke test against a daemon bound to 127.0.0.1 not run in CI — the canned backend covers protocol shape; a follow-up integration test with the real backend will validate end-to-end behavior.

Addresses #122. Does **not** close it — the real backend lands in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
