### PR TITLE
fix(xpu): harden pytorch-xpu index config and clean up XPU follow-ups

### DIFF
--- a/src/transcribe_anything/_xpu_whisper.py
+++ b/src/transcribe_anything/_xpu_whisper.py
@@ -4,6 +4,7 @@ Drop-in replacement for insanely-fast-whisper CLI that supports XPU device.
 
 import argparse
 import json
+
 import torch
 from transformers import pipeline
 
@@ -22,8 +23,17 @@ parser.add_argument("--transcript-path", required=False, default="output.json", 
 parser.add_argument("--model-name", required=False, default="openai/whisper-large-v3", type=str)
 parser.add_argument("--task", required=False, default="transcribe", type=str, choices=["transcribe", "translate"])
 parser.add_argument("--language", required=False, default="None", type=str)
+
+
+def _str_to_bool(value: str) -> bool:
+    """argparse type=bool treats any non-empty string ("False") as truthy."""
+    return value.strip().lower() in ("1", "true", "yes", "on")
+
+
 parser.add_argument("--batch-size", required=False, default=24, type=int)
-parser.add_argument("--flash", required=False, default=False, type=bool)
+# Accepted for CLI parity with insanely-fast-whisper (both bare "--flash" and
+# "--flash True/False"); flash attention is not used on XPU.
+parser.add_argument("--flash", required=False, default=False, type=_str_to_bool, nargs="?", const=True)
 parser.add_argument("--timestamp", required=False, default="chunk", type=str, choices=["chunk", "word"])
 parser.add_argument("--hf-token", required=False, default="no_token", type=str)
 parser.add_argument("--diarization_model", required=False, default="pyannote/speaker-diarization-3.1", type=str)

--- a/src/transcribe_anything/insanely_fast_whisper.py
+++ b/src/transcribe_anything/insanely_fast_whisper.py
@@ -434,7 +434,8 @@ def run_insanely_fast_whisper(
         cmd_list += [
             "python",
             str(xpu_script),
-            "--device-id", "xpu",
+            "--device-id",
+            "xpu",
         ]
     else:
         device_id = get_device_id()

--- a/src/transcribe_anything/insanley_fast_whisper_reqs.py
+++ b/src/transcribe_anything/insanley_fast_whisper_reqs.py
@@ -62,6 +62,10 @@ def _get_reqs_generic(has_nvidia: bool, use_xpu: bool = False) -> list[str]:
     if use_xpu:
         content_lines.append(f"torch=={TENSOR_XPU_VERSION}")
         content_lines.append(f"torchaudio=={TENSOR_XPU_VERSION}")
+        # torch+xpu's triton backend only exists on the pytorch-xpu index
+        # (the PyPI project is quarantined), so it must be a declared
+        # dependency for its [tool.uv.sources] pin to apply.
+        content_lines.append("pytorch-triton-xpu; sys_platform == 'linux' or sys_platform == 'win32'")
     elif has_nvidia:
         content_lines.append(f"torch=={TENSOR_CUDA_VERSION}")
         content_lines.append(f"torchaudio=={TENSOR_CUDA_VERSION}")
@@ -112,19 +116,27 @@ def build_pyproject_toml(has_nvidia: bool, flash: bool = False, use_xpu: bool = 
     content_lines.append("")
     content_lines.append("[tool.uv]")
     if use_xpu:
-        content_lines.append('index-strategy = "unsafe-best-match"')
+        # XPU wheels only exist for linux/windows; keep universal
+        # resolution from failing on the mac split.
+        content_lines.append("environments = [")
+        content_lines.append("    \"sys_platform == 'win32'\",")
+        content_lines.append("    \"sys_platform == 'linux'\",")
+        content_lines.append("]")
     content_lines.append('build-constraint-dependencies = ["setuptools<82"]')
 
     if use_xpu:
+        # Explicit index: only the torch family resolves from pytorch-xpu,
+        # everything else stays on PyPI (mirrors the pytorch-cu128 config).
         content_lines.append("")
         content_lines.append("[tool.uv.sources]")
-        for package in ("torch", "torchaudio"):
+        for package in ("torch", "torchaudio", "pytorch-triton-xpu"):
             content_lines.append(f"{package} = [")
             content_lines.append("  { index = 'pytorch-xpu' },")
             content_lines.append("]")
         content_lines.append("[[tool.uv.index]]")
         content_lines.append('name = "pytorch-xpu"')
         content_lines.append(f'url = "{XPU_EXTRA_INDEX_URL}"')
+        content_lines.append("explicit = true")
     elif has_nvidia:
         content_lines.append("[tool.uv.sources]")
         content_lines.append("torch = [")

--- a/src/transcribe_anything/insanley_fast_whisper_reqs.py
+++ b/src/transcribe_anything/insanley_fast_whisper_reqs.py
@@ -23,6 +23,9 @@ TENSOR_CUDA_VERSION = f"{TENSOR_VERSION}+{CUDA_VERSION}"
 EXTRA_INDEX_URL = f"https://download.pytorch.org/whl/{CUDA_VERSION}"
 XPU_VERSION = "xpu"
 TENSOR_XPU_VERSION = f"{TENSOR_VERSION}+{XPU_VERSION}"
+# torch 2.7.0+xpu requires exactly this triton version; pin it so the
+# resolved artifact is deterministic (index-pinned AND version-pinned).
+TRITON_XPU_VERSION = "3.3.0"
 XPU_EXTRA_INDEX_URL = f"https://download.pytorch.org/whl/{XPU_VERSION}"
 PYTHON_VERSION = "==3.11.*"
 INSANE_ENV_NAME = "insanely_fast_whisper"
@@ -65,7 +68,7 @@ def _get_reqs_generic(has_nvidia: bool, use_xpu: bool = False) -> list[str]:
         # torch+xpu's triton backend only exists on the pytorch-xpu index
         # (the PyPI project is quarantined), so it must be a declared
         # dependency for its [tool.uv.sources] pin to apply.
-        content_lines.append("pytorch-triton-xpu; sys_platform == 'linux' or sys_platform == 'win32'")
+        content_lines.append(f"pytorch-triton-xpu=={TRITON_XPU_VERSION}; sys_platform == 'linux' or sys_platform == 'win32'")
     elif has_nvidia:
         content_lines.append(f"torch=={TENSOR_CUDA_VERSION}")
         content_lines.append(f"torchaudio=={TENSOR_CUDA_VERSION}")

--- a/src/transcribe_anything/whisper.py
+++ b/src/transcribe_anything/whisper.py
@@ -28,10 +28,9 @@ XPU_EXTRA_INDEX_URL = "https://download.pytorch.org/whl/xpu"
 IS_MAC = sys.platform == "darwin"
 
 
-def get_environment(use_xpu: bool = False) -> IsoEnv:
-    """Returns the environment."""
-    venv_dir = get_runtime_venv_dir("whisper-xpu" if use_xpu else "whisper")
-    needs_extra_index = (not IS_MAC and has_nvidia_smi()) or use_xpu
+def build_pyproject_toml(has_nvidia: bool, use_xpu: bool = False) -> str:
+    """Build the uv pyproject content for the isolated whisper env."""
+    needs_extra_index = (not IS_MAC and has_nvidia) or use_xpu
     content_lines: list[str] = []
 
     content_lines.append("[build-system]")
@@ -50,6 +49,10 @@ def get_environment(use_xpu: bool = False) -> IsoEnv:
     if needs_extra_index:
         if use_xpu:
             content_lines.append(f'  "torch=={TENSOR_VERSION}+{XPU_VERSION}",')
+            # torch+xpu's triton backend only exists on the pytorch-xpu
+            # index (the PyPI project is quarantined), so it must be a
+            # declared dependency for its [tool.uv.sources] pin to apply.
+            content_lines.append("  \"pytorch-triton-xpu; sys_platform == 'linux' or sys_platform == 'win32'\",")
         else:
             content_lines.append(f'  "torch=={TENSOR_VERSION}+{CUDA_VERSION}",')
     content_lines.append("]")
@@ -59,11 +62,17 @@ def get_environment(use_xpu: bool = False) -> IsoEnv:
     content_lines.append("")
     content_lines.append("[tool.uv]")
     if use_xpu:
-        content_lines.append('index-strategy = "unsafe-best-match"')
+        # XPU wheels only exist for linux/windows; keep universal
+        # resolution from failing on the mac split.
+        content_lines.append("environments = [")
+        content_lines.append("    \"sys_platform == 'win32'\",")
+        content_lines.append("    \"sys_platform == 'linux'\",")
+        content_lines.append("]")
     content_lines.append('build-constraint-dependencies = ["setuptools<82"]')
 
-    needs_extra_index = (not IS_MAC and has_nvidia_smi()) or use_xpu
     if needs_extra_index:
+        # The extra torch index is explicit: only packages pinned to it via
+        # [tool.uv.sources] resolve from it, everything else stays on PyPI.
         content_lines.append("")
         content_lines.append("[tool.uv.sources]")
         content_lines.append("torch = [")
@@ -72,6 +81,10 @@ def get_environment(use_xpu: bool = False) -> IsoEnv:
         else:
             content_lines.append("  { index = 'pytorch-cu128' },")
         content_lines.append("]")
+        if use_xpu:
+            content_lines.append("pytorch-triton-xpu = [")
+            content_lines.append("  { index = 'pytorch-xpu' },")
+            content_lines.append("]")
         content_lines.append("[[tool.uv.index]]")
         if use_xpu:
             content_lines.append('name = "pytorch-xpu"')
@@ -79,14 +92,15 @@ def get_environment(use_xpu: bool = False) -> IsoEnv:
         else:
             content_lines.append('name = "pytorch-cu128"')
             content_lines.append(f'url = "{CUDA_EXTRA_INDEX_URL}"')
-            content_lines.append("explicit = true")
+        content_lines.append("explicit = true")
 
-    content = "\n".join(content_lines)
+    return "\n".join(content_lines)
 
-    # Debug: Log the pyproject.toml content hash to track changes
-    # content_hash = hashlib.md5(content.encode("utf-8")).hexdigest()[:8]
-    # print(f"Debug: whisper.py pyproject.toml hash: {content_hash}, needs_extra_index: {needs_extra_index}", file=sys.stderr)
 
+def get_environment(use_xpu: bool = False) -> IsoEnv:
+    """Returns the environment."""
+    venv_dir = get_runtime_venv_dir("whisper-xpu" if use_xpu else "whisper")
+    content = build_pyproject_toml(has_nvidia=has_nvidia_smi(), use_xpu=use_xpu)
     pyproject_toml = PyProjectToml(content)
     args = IsoEnvArgs(venv_dir, build_info=pyproject_toml)
     env = IsoEnv(args)

--- a/src/transcribe_anything/whisper.py
+++ b/src/transcribe_anything/whisper.py
@@ -22,6 +22,9 @@ CUDA_AVAILABLE: Optional[bool] = None
 TENSOR_VERSION = "2.7.0"
 CUDA_VERSION = "cu128"
 XPU_VERSION = "xpu"
+# torch 2.7.0+xpu requires exactly this triton version; pin it so the
+# resolved artifact is deterministic (index-pinned AND version-pinned).
+TRITON_XPU_VERSION = "3.3.0"
 CUDA_EXTRA_INDEX_URL = f"https://download.pytorch.org/whl/{CUDA_VERSION}"
 XPU_EXTRA_INDEX_URL = "https://download.pytorch.org/whl/xpu"
 
@@ -52,7 +55,7 @@ def build_pyproject_toml(has_nvidia: bool, use_xpu: bool = False) -> str:
             # torch+xpu's triton backend only exists on the pytorch-xpu
             # index (the PyPI project is quarantined), so it must be a
             # declared dependency for its [tool.uv.sources] pin to apply.
-            content_lines.append("  \"pytorch-triton-xpu; sys_platform == 'linux' or sys_platform == 'win32'\",")
+            content_lines.append(f"  \"pytorch-triton-xpu=={TRITON_XPU_VERSION}; sys_platform == 'linux' or sys_platform == 'win32'\",")
         else:
             content_lines.append(f'  "torch=={TENSOR_VERSION}+{CUDA_VERSION}",')
     content_lines.append("]")

--- a/src/transcribe_anything/whisperx.py
+++ b/src/transcribe_anything/whisperx.py
@@ -247,13 +247,6 @@ def _default_device() -> str:
     return "cuda" if has_nvidia_smi() else "cpu"
 
 
-def _has_intel_gpu() -> bool:
-    """Check if system has Intel GPU support (via oneAPI or similar)."""
-    # This is a simple check; more sophisticated detection could be added later
-    import shutil
-    return shutil.which("sycl-ls") is not None or shutil.which("level-zero-loader") is not None
-
-
 def _format_srt_time(seconds: float) -> str:
     milliseconds = int(round(seconds * 1000))
     hours, remainder = divmod(milliseconds, 3600 * 1000)

--- a/src/transcribe_anything/whisperx_reqs.py
+++ b/src/transcribe_anything/whisperx_reqs.py
@@ -38,12 +38,18 @@ def _torch_requirement(package: str, version: str, has_nvidia: bool, use_xpu: bo
 
 def _get_reqs_generic(has_nvidia: bool, use_xpu: bool = False) -> list[str]:
     """Generate WhisperX backend requirements."""
-    return [
+    reqs = [
         f"whisperx=={WHISPERX_VERSION}",
         _torch_requirement("torch", TORCH_VERSION, has_nvidia, use_xpu=use_xpu),
         _torch_requirement("torchaudio", TORCHAUDIO_VERSION, has_nvidia, use_xpu=use_xpu),
         _torch_requirement("torchvision", TORCHVISION_VERSION, has_nvidia, use_xpu=use_xpu),
     ]
+    if use_xpu:
+        # torch+xpu's triton backend only exists on the pytorch-xpu index
+        # (the PyPI project is quarantined), so it must be a declared
+        # dependency for its [tool.uv.sources] pin to apply.
+        reqs.append("pytorch-triton-xpu; sys_platform == 'linux' or sys_platform == 'win32'")
+    return reqs
 
 
 def build_pyproject_toml(has_nvidia: bool, use_xpu: bool = False) -> str:
@@ -81,13 +87,23 @@ def build_pyproject_toml(has_nvidia: bool, use_xpu: bool = False) -> str:
     elif use_xpu:
         content_lines.append("")
         content_lines.append("[tool.uv]")
-        content_lines.append('index-strategy = "unsafe-best-match"')
-        content_lines.append('override-dependencies = [')
-        content_lines.append('    "torchcodec; python_version < \'3.0\'",')
-        content_lines.append(']')
+        # XPU wheels only exist for linux/windows; keep universal
+        # resolution from failing on the mac split.
+        content_lines.append("environments = [")
+        content_lines.append("    \"sys_platform == 'win32'\",")
+        content_lines.append("    \"sys_platform == 'linux'\",")
+        content_lines.append("]")
+        # torchcodec ships no XPU wheels; the impossible python_version
+        # marker drops it from resolution entirely (whisperx only needs it
+        # for torchaudio's optional decoding path, which XPU does not use).
+        content_lines.append("override-dependencies = [")
+        content_lines.append("    \"torchcodec; python_version < '3.0'\",")
+        content_lines.append("]")
         content_lines.append("")
+        # Explicit index: only the torch family resolves from pytorch-xpu,
+        # everything else stays on PyPI (mirrors the pytorch-cu128 config).
         content_lines.append("[tool.uv.sources]")
-        for package in ("torch", "torchaudio", "torchvision"):
+        for package in ("torch", "torchaudio", "torchvision", "pytorch-triton-xpu"):
             content_lines.append(f"{package} = [")
             content_lines.append("  { index = 'pytorch-xpu' },")
             content_lines.append("]")
@@ -95,6 +111,7 @@ def build_pyproject_toml(has_nvidia: bool, use_xpu: bool = False) -> str:
         content_lines.append("[[tool.uv.index]]")
         content_lines.append('name = "pytorch-xpu"')
         content_lines.append(f'url = "{XPU_EXTRA_INDEX_URL}"')
+        content_lines.append("explicit = true")
 
     return "\n".join(content_lines)
 

--- a/src/transcribe_anything/whisperx_reqs.py
+++ b/src/transcribe_anything/whisperx_reqs.py
@@ -18,6 +18,9 @@ TORCHAUDIO_VERSION = "2.8.0"
 TORCHVISION_VERSION = "0.23.0"
 CUDA_VERSION = "cu128"
 XPU_VERSION = "xpu"
+# torch 2.8.0+xpu requires exactly this triton version; pin it so the
+# resolved artifact is deterministic (index-pinned AND version-pinned).
+TRITON_XPU_VERSION = "3.4.0"
 CUDA_EXTRA_INDEX_URL = f"https://download.pytorch.org/whl/{CUDA_VERSION}"
 XPU_EXTRA_INDEX_URL = "https://download.pytorch.org/whl/xpu"
 
@@ -48,7 +51,7 @@ def _get_reqs_generic(has_nvidia: bool, use_xpu: bool = False) -> list[str]:
         # torch+xpu's triton backend only exists on the pytorch-xpu index
         # (the PyPI project is quarantined), so it must be a declared
         # dependency for its [tool.uv.sources] pin to apply.
-        reqs.append("pytorch-triton-xpu; sys_platform == 'linux' or sys_platform == 'win32'")
+        reqs.append(f"pytorch-triton-xpu=={TRITON_XPU_VERSION}; sys_platform == 'linux' or sys_platform == 'win32'")
     return reqs
 
 

--- a/tests/test_xpu_reqs_hardening.py
+++ b/tests/test_xpu_reqs_hardening.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 import tomllib
 from pathlib import Path
 
+import pytest
+
 SRC = Path(__file__).parent.parent / "src" / "transcribe_anything"
 
 
@@ -57,11 +59,14 @@ def test_whisperx_xpu_pyproject_is_hardened() -> None:
     _assert_hardened_xpu_index(build_pyproject_toml(has_nvidia=False, use_xpu=True))
 
 
-def test_whisper_cuda_pyproject_unchanged() -> None:
+def test_whisper_cuda_pyproject_unchanged(monkeypatch: pytest.MonkeyPatch) -> None:
     """Hardening the XPU path must not disturb the CUDA config."""
-    from transcribe_anything.whisper import build_pyproject_toml
+    import transcribe_anything.whisper as whisper
 
-    content = build_pyproject_toml(has_nvidia=True, use_xpu=False)
+    # The CUDA extra index is only emitted off-mac; force that path so the
+    # assertion holds on macOS CI runners too.
+    monkeypatch.setattr(whisper, "IS_MAC", False)
+    content = whisper.build_pyproject_toml(has_nvidia=True, use_xpu=False)
     idx = content.find('name = "pytorch-cu128"')
     assert idx != -1
     assert "explicit = true" in content[idx:]

--- a/tests/test_xpu_reqs_hardening.py
+++ b/tests/test_xpu_reqs_hardening.py
@@ -34,7 +34,10 @@ def _assert_hardened_xpu_index(content: str) -> None:
     sources = parsed["tool"]["uv"]["sources"]
     assert sources["pytorch-triton-xpu"] == [{"index": "pytorch-xpu"}]
     deps = parsed["project"]["dependencies"]
-    assert any(d.startswith("pytorch-triton-xpu") for d in deps)
+    triton_dep = next(d for d in deps if d.startswith("pytorch-triton-xpu"))
+    # Exact version pin: the resolved artifact must be deterministic, not
+    # whatever latest version appears on the index.
+    assert triton_dep.startswith("pytorch-triton-xpu=="), f"triton must be exact-pinned: {triton_dep}"
     # XPU wheels are linux/windows only; universal resolution must not
     # attempt the mac split.
     environments = parsed["tool"]["uv"]["environments"]

--- a/tests/test_xpu_reqs_hardening.py
+++ b/tests/test_xpu_reqs_hardening.py
@@ -1,0 +1,85 @@
+"""XPU pyproject hardening tests (issue #128).
+
+The pytorch-xpu extra index must be `explicit = true` (only used for packages
+pinned via [tool.uv.sources]) and must not rely on the weaker
+`unsafe-best-match` index strategy — mirroring the existing pytorch-cu128
+config.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+SRC = Path(__file__).parent.parent / "src" / "transcribe_anything"
+
+
+def _assert_hardened_xpu_index(content: str) -> None:
+    """The pytorch-xpu index must be explicit and unsafe-best-match gone."""
+    assert "unsafe-best-match" not in content, "index-strategy = unsafe-best-match must not be used"
+    idx = content.find('name = "pytorch-xpu"')
+    assert idx != -1, "pytorch-xpu index must be declared"
+    assert "explicit = true" in content[idx:], "pytorch-xpu index must set explicit = true"
+    # The generated content must stay valid TOML.
+    parsed = tomllib.loads(content)
+    indexes = parsed["tool"]["uv"]["index"]
+    xpu_index = next(i for i in indexes if i["name"] == "pytorch-xpu")
+    assert xpu_index["url"] == "https://download.pytorch.org/whl/xpu"
+    assert xpu_index["explicit"] is True
+    # pytorch-triton-xpu (torch+xpu's triton backend) is quarantined on PyPI
+    # and only exists on the pytorch-xpu index, so it must be declared and
+    # pinned there for resolution to succeed with an explicit index.
+    sources = parsed["tool"]["uv"]["sources"]
+    assert sources["pytorch-triton-xpu"] == [{"index": "pytorch-xpu"}]
+    deps = parsed["project"]["dependencies"]
+    assert any(d.startswith("pytorch-triton-xpu") for d in deps)
+    # XPU wheels are linux/windows only; universal resolution must not
+    # attempt the mac split.
+    environments = parsed["tool"]["uv"]["environments"]
+    assert set(environments) == {"sys_platform == 'win32'", "sys_platform == 'linux'"}
+
+
+def test_whisper_xpu_pyproject_is_hardened() -> None:
+    from transcribe_anything.whisper import build_pyproject_toml
+
+    _assert_hardened_xpu_index(build_pyproject_toml(has_nvidia=False, use_xpu=True))
+
+
+def test_insane_xpu_pyproject_is_hardened() -> None:
+    from transcribe_anything.insanley_fast_whisper_reqs import build_pyproject_toml
+
+    _assert_hardened_xpu_index(build_pyproject_toml(has_nvidia=False, use_xpu=True))
+
+
+def test_whisperx_xpu_pyproject_is_hardened() -> None:
+    from transcribe_anything.whisperx_reqs import build_pyproject_toml
+
+    _assert_hardened_xpu_index(build_pyproject_toml(has_nvidia=False, use_xpu=True))
+
+
+def test_whisper_cuda_pyproject_unchanged() -> None:
+    """Hardening the XPU path must not disturb the CUDA config."""
+    from transcribe_anything.whisper import build_pyproject_toml
+
+    content = build_pyproject_toml(has_nvidia=True, use_xpu=False)
+    idx = content.find('name = "pytorch-cu128"')
+    assert idx != -1
+    assert "explicit = true" in content[idx:]
+    assert "unsafe-best-match" not in content
+
+
+def test_xpu_whisper_flash_flag_is_store_true() -> None:
+    """argparse `type=bool` treats any non-empty string ("False") as truthy."""
+    src = (SRC / "_xpu_whisper.py").read_text(encoding="utf-8")
+    for line in src.splitlines():
+        if "add_argument" in line:
+            assert "type=bool" not in line, f"raw type=bool parses 'False' as True: {line.strip()}"
+
+
+def test_whisperx_has_no_dead_intel_gpu_helper() -> None:
+    """_has_intel_gpu() was dead code; it must be removed or actually used."""
+    src = (SRC / "whisperx.py").read_text(encoding="utf-8")
+    defined = "_has_intel_gpu" in src
+    if defined:
+        # If it exists it must be called somewhere other than its definition.
+        assert src.count("_has_intel_gpu") > 1, "_has_intel_gpu defined but never called"


### PR DESCRIPTION
Closes #128 — follow-ups from the PR #127 (experimental XPU support) review, plus supply-chain hardening.

## Changes

- **Index hardening (the security item):** the `pytorch-xpu` index is now `explicit = true` in all three backend pyproject generators (`whisper.py`, `insanley_fast_whisper_reqs.py`, `whisperx_reqs.py`), mirroring the existing `pytorch-cu128` config, and `index-strategy = "unsafe-best-match"` is removed. Non-torch packages can now only resolve from PyPI; the torch family can only resolve from download.pytorch.org.
- **`pytorch-triton-xpu` declared, index-pinned, and version-pinned:** torch+xpu depends on it and it only exists on the pytorch-xpu index — the PyPI project is quarantined following the Dec 2022 `torchtriton` dependency-confusion attack, which is exactly the scenario the explicit index protects against. It is exact-pinned (`==3.3.0` for torch 2.7.0+xpu, `==3.4.0` for torch 2.8.0+xpu) so a newer artifact appearing on the index can never change what installs.
- **`tool.uv.environments` limited to linux/windows** for XPU configs, since XPU wheels don't exist for macOS and universal resolution otherwise fails on the mac split.
- Removed dead `_has_intel_gpu()` from `whisperx.py`.
- Fixed `--flash` in `_xpu_whisper.py`: `type=bool` parsed `"False"` as `True`; now a tolerant bool parser accepting both the bare flag and `True`/`False` values (keeps CLI parity with insanely-fast-whisper's `--flash True` form).
- Documented why torchcodec is excluded via `override-dependencies`.

## Verification

- New `tests/test_xpu_reqs_hardening.py` written RED first against the pre-fix code (6 failures), GREEN after (6 passed): asserts explicit index, no unsafe-best-match, exact triton pin, environments limit, valid TOML, CUDA config untouched.
- `uv lock` resolves all three generated **XPU** pyprojects (38/158/125 packages); lockfiles confirmed to pull only torch/torchaudio/torchvision/pytorch-triton-xpu from download.pytorch.org, at exactly the pinned versions.
- `uv lock` resolves all three generated **CUDA** pyprojects (regression check).
- Full test suite: 258 passed, 4 skipped (diarization integration test deselected — fails identically on clean main, pre-existing environmental issue).
- `./lint --no-ruff` clean (black/isort/mypy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)