### PR TITLE
release: 4.1.0 — experimental Intel Arc (XPU) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,22 @@ flowchart TD
 - **99.9% uptime SLA** with enterprise-grade security (SOC 2, HIPAA, ISO 27001)
 - **One API for all meeting platforms** — no platform-specific integrations required
 
+### New in 4.1! 🎉 — Intel Arc GPU support
+
+**Your Intel Arc GPU is now a transcription device.** `--device xpu` runs the blazing HF-pipeline path on PyTorch's XPU backend — Arc A-series and B-series discrete cards and recent Iris Xe iGPUs, on Windows and Linux.
+
+```bash
+transcribe-anything video.mp4 --device xpu
+```
+
+- **Whole-hog isolated env**: torch+xpu wheels pull from PyTorch's official XPU index only — pinned by exact version *and* explicit index, so nothing in the XPU dependency chain can ever resolve from an untrusted source (the `pytorch-triton-xpu` name on PyPI is literally quarantined; we don't go anywhere near it).
+- **WhisperX on Arc too**: the `whisperx` backend gains the same XPU wiring.
+- Experimental — file issues with your card model if something misbehaves.
+
+Also in 4.1: dependency security refresh across every isolated backend env (`yt-dlp` 2026.7.4, `cryptography` 49.0.0, per-env torch updates, and a 36-package dead-weight drop from the `insane` env).
+
+Thanks to [@Mischala](https://github.com/Mischala) for kicking off the XPU support (#127, closes #23).
+
 ### New in 4.0! 🎉
 
 **Three new backends, phoneme-precise word-level timestamps for the fast path, and read-only installs.** This is the biggest release since the `--device insane` debut. If you ran 3.2 and squinted at end-of-audio timestamps, this is the one to upgrade to.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "httpx>=0.27.0",
 ]
 # VERSION
-version = "4.0.0"  # Update this manually or configure setuptools-scm for automatic versioning
+version = "4.1.0"  # Update this manually or configure setuptools-scm for automatic versioning
 maintainers = [{ name = "Zachary Vorhies", email = "dont@email.me" }]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Bumps version 4.0.0 → 4.1.0 and adds the **New in 4.1 — Intel Arc GPU support** section to the README (front and center, above the 4.0 notes).

## In this release (already on main)

- `--device xpu`: experimental Intel Arc support via PyTorch XPU wheels (#127, closes #23) — thanks @Mischala
- Supply-chain hardening: explicit `pytorch-xpu` index + exact `torch`/`triton` pins (#129, closes #128)
- Dependency security refresh: `yt-dlp` 2026.7.4, `cryptography` 49.0.0, per-env torch updates (2.10.0 whisper / 2.7.1 insane), srtranslator dead-weight removal (#130) — 0 open Dependabot alerts
- README architecture diagram (#131)

## Release plan after merge

Tag `v4.1.0` on the merge commit, then publish to PyPI via `upload_package.sh` (repo's manual twine flow — no tag-triggered workflow exists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)