### PR TITLE
fix(xpu): select compatible Python for backend environments

### DIFF
--- a/src/transcribe_anything/insanley_fast_whisper_reqs.py
+++ b/src/transcribe_anything/insanley_fast_whisper_reqs.py
@@ -13,6 +13,7 @@ from transcribe_anything.flash_attention_wheels import (
     get_flash_attention_wheel,
 )
 from transcribe_anything.util import get_runtime_venv_dir, has_nvidia_smi
+from transcribe_anything.xpu_iso_env import XpuIsoEnv
 
 HERE = Path(__file__).parent
 
@@ -184,5 +185,5 @@ def get_environment(has_nvidia: bool | None = None, flash: bool = False, use_xpu
     content = build_pyproject_toml(has_nvidia=has_nvidia, flash=flash, use_xpu=use_xpu)
     build_info = PyProjectToml(content)
     args = IsoEnvArgs(venv_path=venv_dir, build_info=build_info)
-    env = IsoEnv(args)
+    env = XpuIsoEnv(args, python="3.11") if use_xpu else IsoEnv(args)
     return env

--- a/src/transcribe_anything/whisper.py
+++ b/src/transcribe_anything/whisper.py
@@ -11,6 +11,7 @@ from typing import Optional
 from iso_env import IsoEnv, IsoEnvArgs, PyProjectToml  # type: ignore
 
 from transcribe_anything.util import get_runtime_venv_dir, has_nvidia_smi
+from transcribe_anything.xpu_iso_env import XpuIsoEnv
 
 # from isolated_environment import isolated_environment  # type: ignore
 
@@ -107,7 +108,7 @@ def get_environment(use_xpu: bool = False) -> IsoEnv:
     content = build_pyproject_toml(has_nvidia=has_nvidia_smi(), use_xpu=use_xpu)
     pyproject_toml = PyProjectToml(content)
     args = IsoEnvArgs(venv_dir, build_info=pyproject_toml)
-    env = IsoEnv(args)
+    env = XpuIsoEnv(args, python="3.10") if use_xpu else IsoEnv(args)
     return env
 
 

--- a/src/transcribe_anything/whisperx_reqs.py
+++ b/src/transcribe_anything/whisperx_reqs.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from iso_env import IsoEnv, IsoEnvArgs, PyProjectToml  # type: ignore
 
 from transcribe_anything.util import get_runtime_venv_dir, has_nvidia_smi
+from transcribe_anything.xpu_iso_env import XpuIsoEnv
 
 HERE = Path(__file__).parent
 
@@ -126,5 +127,5 @@ def get_environment(has_nvidia: bool | None = None, use_xpu: bool = False) -> Is
         has_nvidia = has_nvidia_smi()
     build_info = PyProjectToml(build_pyproject_toml(has_nvidia, use_xpu=use_xpu))
     args = IsoEnvArgs(venv_path=venv_dir, build_info=build_info)
-    env = IsoEnv(args)
+    env = XpuIsoEnv(args, python="3.11") if use_xpu else IsoEnv(args)
     return env

--- a/src/transcribe_anything/xpu_iso_env.py
+++ b/src/transcribe_anything/xpu_iso_env.py
@@ -1,0 +1,86 @@
+"""Compatibility guard for XPU backends managed by uv-iso-env."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from filelock import FileLock
+from iso_env import IsoEnv, IsoEnvArgs  # type: ignore
+from iso_env.api import installed, purge  # type: ignore
+from iso_env.util import get_verbose_from_env  # type: ignore
+
+
+class XpuIsoEnv(IsoEnv):
+    """Install an XPU backend with an XPU-wheel-compatible Python.
+
+    uv-iso-env 1.0.44 invokes ``uv venv`` and ``uv pip compile`` without a
+    Python request. That makes both commands inherit the host interpreter,
+    even when the generated project declares an older ``requires-python``.
+    It also marks the environment installed after a compile failure. Keep
+    this strict installer local to XPU environments until upstream exposes
+    interpreter selection and propagates compile failures.
+    """
+
+    def __init__(self, args: IsoEnvArgs, *, python: str) -> None:
+        super().__init__(args)
+        self.python = python
+
+    @property
+    def _compiled_requirements(self) -> Path:
+        return self.args.venv_path / "requirements.compiled.txt"
+
+    def _is_complete(self, *, verbose: bool) -> bool:
+        return installed(self.args, verbose=verbose) and self._compiled_requirements.is_file() and self._compiled_requirements.stat().st_size > 0
+
+    def _run_uv(self, cmd: list[str], *, cwd: Path) -> None:
+        try:
+            subprocess.run(cmd, cwd=str(cwd), check=True, capture_output=True, text=True, shell=False)
+        except subprocess.CalledProcessError as exc:
+            detail = (exc.stderr or exc.stdout or "<no output captured>").strip()
+            raise RuntimeError(f"XPU dependency installation failed while running {subprocess.list2cmdline(cmd)}: {detail}") from exc
+
+    def _ensure_installed(self) -> None:
+        path = self.args.venv_path.resolve()
+        lock_path = path.parent / f".{path.name}.lock"
+        lock_path.parent.mkdir(exist_ok=True, parents=True)
+        verbose = get_verbose_from_env()
+
+        with FileLock(str(lock_path), timeout=300):
+            if self._is_complete(verbose=verbose):
+                return
+            purge(path)
+            path.mkdir(exist_ok=True, parents=True)
+            (path / "pyproject.toml").write_text(str(self.args.build_info), encoding="utf-8")
+            uv = shutil.which("uv")
+            if uv is None:
+                raise RuntimeError("XPU dependency installation failed: uv was not found on PATH")
+            try:
+                self._run_uv([uv, "venv", "--python", self.python], cwd=path)
+                self._run_uv(
+                    [
+                        uv,
+                        "pip",
+                        "compile",
+                        "pyproject.toml",
+                        "--python",
+                        self.python,
+                        "--output-file",
+                        "requirements.compiled.txt",
+                    ],
+                    cwd=path,
+                )
+            except BaseException:
+                (path / "installed").unlink(missing_ok=True)
+                raise
+            (path / "installed").touch()
+
+    def run(self, cmd_list: list[str], **process_args: Any) -> subprocess.CompletedProcess[Any]:
+        self._ensure_installed()
+        return super().run(cmd_list, **process_args)
+
+    def open_proc(self, cmd_list: list[str], **process_args: Any) -> subprocess.Popen[Any]:
+        self._ensure_installed()
+        return super().open_proc(cmd_list, **process_args)

--- a/tests/test_xpu_python_compat.py
+++ b/tests/test_xpu_python_compat.py
@@ -1,0 +1,87 @@
+"""Regression tests for XPU environments launched from newer host Pythons."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+from iso_env import IsoEnvArgs, PyProjectToml
+
+from transcribe_anything.xpu_iso_env import XpuIsoEnv
+
+
+def _args(tmp_path: Path) -> IsoEnvArgs:
+    return IsoEnvArgs(
+        venv_path=tmp_path / "xpu-env",
+        build_info=PyProjectToml('[project]\nname = "test"\nversion = "0.0.0"\nrequires-python = "==3.11.*"'),
+    )
+
+
+@pytest.mark.parametrize("method", ["run", "open_proc"])
+def test_xpu_env_requests_compatible_python_during_install(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, method: str) -> None:
+    """Issue #134: never resolve XPU wheels with the CPython 3.14 host ABI."""
+    args = _args(tmp_path)
+    env = XpuIsoEnv(args, python="3.11")
+    observed: list[list[str]] = []
+    sentinel = object()
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        del kwargs
+        observed.append(cmd)
+        if "compile" in cmd:
+            (args.venv_path / "requirements.compiled.txt").write_text("torch==2.7.1+xpu\n")
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr("transcribe_anything.xpu_iso_env.shutil.which", lambda name: "uv")
+    monkeypatch.setattr("transcribe_anything.xpu_iso_env.subprocess.run", fake_run)
+    monkeypatch.setattr(f"iso_env.IsoEnv.{method}", lambda *args, **kwargs: sentinel)
+
+    assert getattr(env, method)(["python", "-V"]) is sentinel
+    assert observed[0] == ["uv", "venv", "--python", "3.11"]
+    assert observed[1][:4] == ["uv", "pip", "compile", "pyproject.toml"]
+    assert observed[1][4:6] == ["--python", "3.11"]
+
+
+def test_xpu_env_rejects_false_installed_marker_after_compile_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A dependency compile failure must be fatal and must not be cached."""
+    args = _args(tmp_path)
+    env = XpuIsoEnv(args, python="3.11")
+    args.venv_path.mkdir(parents=True)
+    installed = args.venv_path / "installed"
+    installed.touch()
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        del kwargs
+        if "compile" in cmd:
+            raise subprocess.CalledProcessError(1, cmd, stderr="no cp314 wheel")
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr("transcribe_anything.xpu_iso_env.shutil.which", lambda name: "uv")
+    monkeypatch.setattr("transcribe_anything.xpu_iso_env.subprocess.run", fake_run)
+
+    with pytest.raises(RuntimeError, match="no cp314 wheel"):
+        env.open_proc(["python", "-V"])
+
+    assert not installed.exists()
+
+
+@pytest.mark.parametrize(
+    ("module_name", "expected_python"),
+    [
+        ("transcribe_anything.whisper", "3.10"),
+        ("transcribe_anything.insanley_fast_whisper_reqs", "3.11"),
+        ("transcribe_anything.whisperx_reqs", "3.11"),
+    ],
+)
+def test_xpu_environment_factories_pin_the_backend_python(module_name: str, expected_python: str, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    module = __import__(module_name, fromlist=["get_environment"])
+    monkeypatch.setattr(module, "get_runtime_venv_dir", lambda name: tmp_path / name)
+    if hasattr(module, "has_nvidia_smi"):
+        monkeypatch.setattr(module, "has_nvidia_smi", lambda: False)
+
+    env = module.get_environment(use_xpu=True)
+
+    assert isinstance(env, XpuIsoEnv)
+    assert env.python == expected_python


### PR DESCRIPTION
## Summary

- install XPU backend environments with an explicit compatible Python (`3.10` for Whisper, `3.11` for insane/WhisperX)
- fail dependency compilation instead of accepting `uv-iso-env`'s false `installed` marker
- cover both synchronous and asynchronous environment launch paths without requiring Intel hardware

Closes #134

## Validation

- `pytest -q` — 264 passed, 8 skipped
- focused XPU tests — 12 passed
- Black, isort, Ruff, and mypy on changed files
- real lightweight iso-env probe: CPython 3.11 selected and launched successfully
- forced impossible dependency: fatal error and no `installed` marker
- Intel XPU index metadata resolved for:
  - torch/torchaudio 2.7.1+xpu + pytorch-triton-xpu 3.3.1 on Python 3.11
  - torch/torchaudio 2.8.0+xpu + torchvision 0.23.0+xpu + pytorch-triton-xpu 3.4.0 on Python 3.11
  - torch 2.10.0+xpu + triton-xpu 3.6.0 on Python 3.10

Actual Arc inference was not rerun locally because no Intel GPU is attached; @Mischala already confirmed the inference path in PR #127, and this change is limited to environment construction before inference.