### PR TITLE
release: 4.1.1 — XPU Python compatibility fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "httpx>=0.27.0",
 ]
 # VERSION
-version = "4.1.0"  # Update this manually or configure setuptools-scm for automatic versioning
+version = "4.1.1"  # Update this manually or configure setuptools-scm for automatic versioning
 maintainers = [{ name = "Zachary Vorhies", email = "dont@email.me" }]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Patch release for the CPython 3.14 host / Intel XPU environment fix merged in #135.

## Included

- Explicitly select a compatible backend Python for XPU environment creation.
- Treat dependency compilation failures as fatal; never cache a false installed marker.
- Hardware-independent regression coverage for synchronous and asynchronous launches.

## Validation

- PR #135: all seven GitHub checks green; 264 local tests passed, 8 skipped.
- Post-merge current-main validation: 12 focused tests passed; real Python 3.11 environment launch succeeded; forced resolution failure left no installed marker.
- Built `transcribe_anything-4.1.1-py3-none-any.whl` and verified `Version: 4.1.1` in wheel metadata.

After merge: publish 4.1.1 using the repository's established annotated-tag + Twine + GitHub Release flow.